### PR TITLE
Fix: ensure no rounding when placing limit orders

### DIFF
--- a/py_clob_client/orders/builder.py
+++ b/py_clob_client/orders/builder.py
@@ -38,18 +38,16 @@ class OrderBuilder:
             maker_asset_id = None
             taker_asset_id = int(order_args.token_id)
 
-            size_normalized = round_down(order_args.size, 2)
-            maker_amount = to_token_decimals(round_down(order_args.price * size_normalized, 2))
-            taker_amount = to_token_decimals(size_normalized)
+            maker_amount = to_token_decimals(order_args.price * order_args.size)
+            taker_amount = to_token_decimals(order_args.size)
         else:
             maker_asset = self.contract_config.get_conditional()
             taker_asset = self.contract_config.get_collateral()
             maker_asset_id = int(order_args.token_id)
             taker_asset_id = None
 
-            size_normalized = round_down(order_args.size, 2)
-            maker_amount = to_token_decimals(size_normalized)
-            taker_amount = to_token_decimals(round_down(order_args.price * size_normalized, 2))
+            maker_amount = to_token_decimals(order_args.size)
+            taker_amount = to_token_decimals(order_args.price * order_args.size)
 
         data = LimitOrderData(
                 exchange_address=self.contract_config.get_exchange(),


### PR DESCRIPTION
- When placing limit orders, we currently generate the maker and taker amounts and round them
- This has led to intermittent "price breaks minimum tick size rule" error on the CLOB:
E.g placing a sell order with the following
```
price = 0.65
size = 45.45
maker_amount = 45.45
taker_amount = round_down(price * size, 2) = 29.54
# On the CLOB, we'll calculate price:
taker_amount / maker_amount = 0.6499449944994499 #  which breaks the minimum tick size rule
```

This can be fixed by removing the rounding on the maker_amount or taker_amount:
```
price = 0.65
size = 45.45
maker_amount = size = 45.45
taker_amount = price * size = 29.542500000000004
Price on CLOB = taker_amount / maker_amount = price * size / size = exact price = 0.65
```