### PR TITLE
Update builder.py

### DIFF
--- a/py_clob_client/order_builder/builder.py
+++ b/py_clob_client/order_builder/builder.py
@@ -9,7 +9,7 @@ from .helpers import (
     decimal_places,
     round_up,
 )
-from .constants import BUY
+from .constants import BUY, SELL
 
 from ..signer import Signer
 from ..clob_types import OrderArgs
@@ -52,7 +52,7 @@ class OrderBuilder:
 
             maker_amount = to_token_decimals(raw_maker_amt)
             taker_amount = to_token_decimals(raw_taker_amt)
-        else:
+        elif order_args.side == SELL:
             side = 1
 
             raw_maker_amt = round_down(order_args.size, 2)
@@ -66,6 +66,8 @@ class OrderBuilder:
 
             maker_amount = to_token_decimals(raw_maker_amt)
             taker_amount = to_token_decimals(raw_taker_amt)
+        else:
+            raise ValueError(f"order_args.side must be '{BUY}' or '{SELL}'")
 
         data = OrderData(
             maker=self.funder,


### PR DESCRIPTION
Modifies create_order() to enforce that order_args.side must be 'buy' or 'sell'.  This will avoid accidental sells from passing arguments like 'Buy', 'buy ', or 'bid'.  
