### PR TITLE
Feat/ New order type: GTD

### DIFF
--- a/examples/GTD_order.py
+++ b/examples/GTD_order.py
@@ -1,0 +1,39 @@
+import os
+
+from py_clob_client.client import ClobClient
+from py_clob_client.clob_types import ApiCreds, OrderArgs, OrderType
+from dotenv import load_dotenv
+from py_clob_client.constants import MUMBAI
+
+from py_clob_client.order_builder.constants import BUY
+
+
+load_dotenv()
+
+
+def main():
+    host = "http://localhost:8080"
+    key = os.getenv("PK")
+    creds = ApiCreds(
+        api_key=os.getenv("CLOB_API_KEY"),
+        api_secret=os.getenv("CLOB_SECRET"),
+        api_passphrase=os.getenv("CLOB_PASS_PHRASE"),
+    )
+    chain_id = MUMBAI
+    client = ClobClient(host, key=key, chain_id=chain_id, creds=creds)
+
+    # Create and sign a limit order buying 100 YES tokens for 0.50c each
+    order_args = OrderArgs(
+        price=0.50,
+        size=100.0,
+        side=BUY,
+        token_id="16678291189211314787145083999015737376658799626183230671758641503291735614088",
+        expiration="1000000000000",
+    )
+    signed_order = client.create_order(order_args)
+    resp = client.post_order(signed_order, OrderType.GTD)
+    print(resp)
+    print("Done!")
+
+
+main()

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -1,7 +1,7 @@
 import logging
 
 from .order_builder.builder import OrderBuilder
-from .clob_types import ApiCreds
+from .clob_types import ApiCreds, OrderType
 
 from .headers.headers import create_level_1_headers, create_level_2_headers
 from .signer import Signer
@@ -48,7 +48,11 @@ from .http_helpers.helpers import (
 )
 from py_order_utils.config import get_contract_config
 from .constants import L0, L1, L1_AUTH_UNAVAILABLE, L2, L2_AUTH_UNAVAILABLE
-from .utilities import parse_raw_orderbook_summary, generate_orderbook_summary_hash
+from .utilities import (
+    parse_raw_orderbook_summary,
+    generate_orderbook_summary_hash,
+    order_to_json,
+)
 
 
 class ClobClient:
@@ -227,12 +231,12 @@ class ClobClient:
 
         return self.builder.create_order(order_args)
 
-    def post_order(self, order):
+    def post_order(self, order, orderType: OrderType = OrderType.GTC):
         """
         Posts the order
         """
         self.assert_level_2_auth()
-        body = {"order": order.dict(), "owner": self.creds.api_key, "orderType": "GTC"}
+        body = order_to_json(order, self.creds.api_key, orderType)
         headers = create_level_2_headers(
             self.signer,
             self.creds,

--- a/py_clob_client/clob_types.py
+++ b/py_clob_client/clob_types.py
@@ -120,3 +120,10 @@ class AssetType(enumerate):
 class BalanceAllowanceParams:
     asset_type: AssetType = None
     token_id: str = None
+
+
+class OrderType(enumerate):
+    GTC = "GTC"
+    # TODO: add support for FOK orders
+    FOK = "FOK"
+    GTD = "GTD"

--- a/py_clob_client/utilities.py
+++ b/py_clob_client/utilities.py
@@ -29,3 +29,7 @@ def generate_orderbook_summary_hash(orderbook: OrderBookSummary) -> str:
     hash = hashlib.sha1(str(orderbook.json).encode("utf-8")).hexdigest()
     orderbook.hash = hash
     return hash
+
+
+def order_to_json(order, owner, orderType) -> dict:
+    return {"order": order.dict(), "owner": owner, "orderType": orderType}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="py_clob_client",
-    version="0.2.4",
+    version="0.3.0",
     author="Polymarket Engineering",
     author_email="engineering@polymarket.com",
     maintainer="Polymarket Engineering",

--- a/tests/order_builder/test_builder.py
+++ b/tests/order_builder/test_builder.py
@@ -195,6 +195,27 @@ class TestOrderBuilder(TestCase):
             8213000,
         )
 
+        # BUY
+        signed_order = builder.create_order(
+            order_args=OrderArgs(
+                token_id="123",
+                price=0.58,
+                size=18233.33,
+                side=BUY,
+            )
+        )
+        self.assertEqual(
+            signed_order.order["makerAmount"],
+            10575331400,
+        )
+        self.assertEqual(
+            signed_order.order["takerAmount"],
+            18233330000,
+        )
+        self.assertEqual(
+            signed_order.order["makerAmount"] / signed_order.order["takerAmount"], 0.58
+        )
+
     def test_create_order_buy(self):
         builder = OrderBuilder(signer)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,8 +1,14 @@
 from unittest import TestCase
 
+from py_clob_client.clob_types import OrderArgs, OrderType
+from py_clob_client.constants import MUMBAI
+from py_clob_client.order_builder.constants import BUY, SELL
+from py_clob_client.signer import Signer
+from py_clob_client.order_builder.builder import OrderBuilder
 from py_clob_client.utilities import (
     parse_raw_orderbook_summary,
     generate_orderbook_summary_hash,
+    order_to_json,
 )
 
 
@@ -144,3 +150,165 @@ class TestUtilities(TestCase):
             orderbook_summary.hash,
             "7f81a35a09e1933a96b05edb51ac4be4a6163146",
         )
+
+    def test_order_to_json(self):
+        # publicly known private key
+        private_key = (
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        )
+        chain_id = MUMBAI
+        signer = Signer(private_key=private_key, chain_id=chain_id)
+        owner = "aaa-bbb-ccc"
+        builder = OrderBuilder(signer)
+
+        # GTC BUY
+        json_order = order_to_json(
+            order=builder.create_order(
+                order_args=OrderArgs(
+                    token_id="100",
+                    price=0.5,
+                    size=100,
+                    side=BUY,
+                )
+            ),
+            owner=owner,
+            orderType=OrderType.GTC,
+        )
+
+        self.assertIsNotNone(json_order)
+        self.assertEqual(json_order["orderType"], "GTC")
+        self.assertEqual(json_order["owner"], owner)
+        self.assertIsNotNone(json_order["order"])
+        self.assertIsNotNone(json_order["order"]["salt"])
+        self.assertEqual(
+            json_order["order"]["maker"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["signer"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["taker"], "0x0000000000000000000000000000000000000000"
+        )
+        self.assertEqual(json_order["order"]["tokenId"], "100")
+        self.assertEqual(json_order["order"]["makerAmount"], "50000000")
+        self.assertEqual(json_order["order"]["takerAmount"], "100000000")
+        self.assertEqual(json_order["order"]["expiration"], "0")
+        self.assertEqual(json_order["order"]["nonce"], "0")
+        self.assertEqual(json_order["order"]["feeRateBps"], "0")
+        self.assertEqual(json_order["order"]["side"], "BUY")
+        self.assertEqual(json_order["order"]["signatureType"], 0)
+        self.assertIsNotNone(json_order["order"]["signature"])
+
+        # GTC SELL
+        json_order = order_to_json(
+            order=builder.create_order(
+                order_args=OrderArgs(
+                    token_id="100",
+                    price=0.5,
+                    size=100,
+                    side=SELL,
+                )
+            ),
+            owner=owner,
+            orderType=OrderType.GTC,
+        )
+
+        self.assertIsNotNone(json_order)
+        self.assertEqual(json_order["orderType"], "GTC")
+        self.assertEqual(json_order["owner"], owner)
+        self.assertIsNotNone(json_order["order"])
+        self.assertIsNotNone(json_order["order"]["salt"])
+        self.assertEqual(
+            json_order["order"]["maker"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["signer"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["taker"], "0x0000000000000000000000000000000000000000"
+        )
+        self.assertEqual(json_order["order"]["tokenId"], "100")
+        self.assertEqual(json_order["order"]["makerAmount"], "100000000")
+        self.assertEqual(json_order["order"]["takerAmount"], "50000000")
+        self.assertEqual(json_order["order"]["expiration"], "0")
+        self.assertEqual(json_order["order"]["nonce"], "0")
+        self.assertEqual(json_order["order"]["feeRateBps"], "0")
+        self.assertEqual(json_order["order"]["side"], "SELL")
+        self.assertEqual(json_order["order"]["signatureType"], 0)
+        self.assertIsNotNone(json_order["order"]["signature"])
+
+        # GTD BUY
+        json_order = order_to_json(
+            order=builder.create_order(
+                order_args=OrderArgs(
+                    token_id="100",
+                    price=0.5,
+                    size=100,
+                    side=BUY,
+                )
+            ),
+            owner=owner,
+            orderType=OrderType.GTD,
+        )
+
+        self.assertIsNotNone(json_order)
+        self.assertEqual(json_order["orderType"], "GTD")
+        self.assertEqual(json_order["owner"], owner)
+        self.assertIsNotNone(json_order["order"])
+        self.assertIsNotNone(json_order["order"]["salt"])
+        self.assertEqual(
+            json_order["order"]["maker"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["signer"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["taker"], "0x0000000000000000000000000000000000000000"
+        )
+        self.assertEqual(json_order["order"]["tokenId"], "100")
+        self.assertEqual(json_order["order"]["makerAmount"], "50000000")
+        self.assertEqual(json_order["order"]["takerAmount"], "100000000")
+        self.assertEqual(json_order["order"]["expiration"], "0")
+        self.assertEqual(json_order["order"]["nonce"], "0")
+        self.assertEqual(json_order["order"]["feeRateBps"], "0")
+        self.assertEqual(json_order["order"]["side"], "BUY")
+        self.assertEqual(json_order["order"]["signatureType"], 0)
+        self.assertIsNotNone(json_order["order"]["signature"])
+
+        # GTD SELL
+        json_order = order_to_json(
+            order=builder.create_order(
+                order_args=OrderArgs(
+                    token_id="100",
+                    price=0.5,
+                    size=100,
+                    side=SELL,
+                )
+            ),
+            owner=owner,
+            orderType=OrderType.GTD,
+        )
+
+        self.assertIsNotNone(json_order)
+        self.assertEqual(json_order["orderType"], "GTD")
+        self.assertEqual(json_order["owner"], owner)
+        self.assertIsNotNone(json_order["order"])
+        self.assertIsNotNone(json_order["order"]["salt"])
+        self.assertEqual(
+            json_order["order"]["maker"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["signer"], "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        )
+        self.assertEqual(
+            json_order["order"]["taker"], "0x0000000000000000000000000000000000000000"
+        )
+        self.assertEqual(json_order["order"]["tokenId"], "100")
+        self.assertEqual(json_order["order"]["makerAmount"], "100000000")
+        self.assertEqual(json_order["order"]["takerAmount"], "50000000")
+        self.assertEqual(json_order["order"]["expiration"], "0")
+        self.assertEqual(json_order["order"]["nonce"], "0")
+        self.assertEqual(json_order["order"]["feeRateBps"], "0")
+        self.assertEqual(json_order["order"]["side"], "SELL")
+        self.assertEqual(json_order["order"]["signatureType"], 0)
+        self.assertIsNotNone(json_order["order"]["signature"])


### PR DESCRIPTION


<!-- Delete any sub-sections not used rather than leaving them empty. -->

## Overview

This PR includes a new type of order: `GTD`.

The `GTD` orders have the ability to expire when the time expressed in its field called `expiration` arrives.

The timestamp must be expressed in UNIX timestamp (seconds) using the `UTC` location.

### Security threshold

As the Clob needs some time to process, match and submit a trade, there is a security threshold for GTD orders. This value is `10s` (10 seconds).

So when an order is about 10 seconds from its expiration timestamp, the Clob will expire it.

For example, if we need a `1m` expiration order we should use a timestamp that represents this: `UTC NOW + 1m + 10s`.
## Types of changes

<!-- Check one of the boxes below, and add additional information as necessary. -->

- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [ ] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [x] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

## Notes

<!-- Include any additional comments, links, questions, or discussion items here. -->

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [x] Add tests to cover changes as needed.
- [ ] Update documentation/changelog as needed.
- [x] Verify all tests run correctly in CI and pass.
- [ ] Ready for review/merge.
