### PR TITLE
Update get_balance_allowance.py

### DIFF
--- a/examples/get_balance_allowance.py
+++ b/examples/get_balance_allowance.py
@@ -33,8 +33,10 @@ def main():
     print(yes)
 
     no = client.get_balance_allowance(
-        params=BalanceAllowanceParams(asset_type=AssetType.CONDITIONAL),
+        params=BalanceAllowanceParams(
+            asset_type=AssetType.CONDITIONAL,
         token_id="16678291189211314787145083999015737376658799626183230671758641503291735614088",
+        )
     )
     print(no)
 


### PR DESCRIPTION


## Overview

Fixed a syntax error/typo that was not allowing this example to execute properly. 
## Description

There is an error/typo in the no portion of this example. The Param was  not formatted properly. Specefically the token_id was not included inside the BalanceAlowanceParams. I believe the ")" was just moved or put into the wrong place;  Resulting in the following error:
TypeError: get_balance_allowance() got an unexpected keyword argument 'token_id'


I resolved it by moving the token_id to the right place.



## Types of changes


- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [x] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

