### PR TITLE
Fix missing next_cursor in add_query_*_params()

### DIFF
--- a/py_clob_client/http_helpers/helpers.py
+++ b/py_clob_client/http_helpers/helpers.py
@@ -76,8 +76,9 @@ def add_query_trade_params(
     Adds query parameters to a url
     """
     url = base_url
-    if params:
+    if params or next_cursor:
         url = url + "?"
+    if params:
         if params.market:
             url = build_query_params(url, "market", params.market)
         if params.asset_id:
@@ -90,8 +91,8 @@ def add_query_trade_params(
             url = build_query_params(url, "maker_address", params.maker_address)
         if params.id:
             url = build_query_params(url, "id", params.id)
-        if next_cursor:
-            url = build_query_params(url, "next_cursor", next_cursor)
+    if next_cursor:
+        url = build_query_params(url, "next_cursor", next_cursor)
     return url
 
 
@@ -102,16 +103,17 @@ def add_query_open_orders_params(
     Adds query parameters to a url
     """
     url = base_url
-    if params:
+    if params or next_cursor:
         url = url + "?"
+    if params:
         if params.market:
             url = build_query_params(url, "market", params.market)
         if params.asset_id:
             url = build_query_params(url, "asset_id", params.asset_id)
         if params.id:
             url = build_query_params(url, "id", params.id)
-        if next_cursor:
-            url = build_query_params(url, "next_cursor", next_cursor)
+    if next_cursor:
+        url = build_query_params(url, "next_cursor", next_cursor)
     return url
 
 


### PR DESCRIPTION
## Overview

When get_active_orders() and get_trades() are used without supplying params, pagination goes into infinite loop. This is because the code to set next_cursor is indented inside the check for params presence.

## Description

Unindent the code that sets next_cursor.

## Testing instructions

In order to reproduce the broken behavior, an account that has > 500 items returned by API is required.

## Types of changes

- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [X] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->