### PR TITLE
Make params required as it should be

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -616,7 +616,7 @@ class ClobClient:
         )
         return delete(url, headers=headers)
 
-    def get_balance_allowance(self, params: BalanceAllowanceParams = None):
+    def get_balance_allowance(self, params: BalanceAllowanceParams):
         """
         Fetches the balance & allowance for a user
         Requires Level 2 authentication


### PR DESCRIPTION
## Overview

`params` is required for `client.get_balance_allowance(params)`, so we should make it explicit and make the user specify the argument.

## Description

Instead of using a default of None, make sure that `params` is always specified for get_balance_allowance.

## Testing instructions

No testing needed, simple change to make param a requirement. It fails right now if the params is not passed in.

## Types of changes

<!-- Check one of the boxes below, and add additional information as necessary. -->

- [X] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [X] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->


## Status


- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation/changelog as needed.
- [ ] Verify all tests run correctly in CI and pass.
- [X ] Ready for review/merge.
