### PR TITLE
Added Interactive Notebooks to /examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.DS_Store

--- a/examples/interactive_notebooks/gamma-market-info.ipynb
+++ b/examples/interactive_notebooks/gamma-market-info.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For practice lets write a script loop to fetch releveant market info for a given slug. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Basic Imports\n",
+    "import os\n",
+    "import json\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Every outcome of a given Market is \"tokenized\". Meaning there is a YES token and a NO token. This is what we are trading when using the platform. At resolution is when the tokens gain value with the correct outcome token able to be \"redeemed\" for 1USDC. There's more to it but this covers the basics of what you'll need to know today. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets try this and get the tokens for a single market. The easiest way to get information on a specefic market is to visit that market in the browser and grab the slug from the url. It's the hyphenated description in the url. For example https://polymarket.com/event/nba-champion-2024-2025?tid=1746760343141\n",
+    "\n",
+    "The events endpoint will return a list of market objects associated with that event. As we will see later. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected Slug: how-many-fed-rate-cuts-in-2025\n"
+     ]
+    }
+   ],
+   "source": [
+    "slug = input(\"Event or Market Slug to get information for: \")\n",
+    "print(f\"Selected Slug: {slug}\")\n",
+    "base_url = \"https://gamma-api.polymarket.com/events?active=true&closed=false&slug=\"\n",
+    "all_data = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'id': '16085', 'ticker': 'how-many-fed-rate-cuts-in-2025', 'slug': 'how-many-fed-rate-cuts-in-2025', 'title': 'How many Fed rate cuts in 2025?', 'description': 'This is a market group over how many Fed rate cuts will happen in 2025.', 'resolutionSource': '', 'startDate': '2024-12-29T22:50:43.348587Z', 'creationDate': '2024-12-29T22:50:43.348584Z', 'endDate': '2025-12-31T12:00:00Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'active': True, 'closed': False, 'archived': False, 'new': False, 'featured': True, 'restricted': True, 'liquidity': 802831.28134, 'volume': 6942089.980486, 'openInterest': 0, 'createdAt': '2024-12-29T17:39:19.350409Z', 'updatedAt': '2025-05-12T19:04:39.841928Z', 'competitive': 0.9248768757659137, 'volume24hr': 189593.687811, 'volume1wk': 486307.70667299995, 'volume1mo': 1316098.44308, 'volume1yr': 6927149.539412999, 'enableOrderBook': True, 'liquidityClob': 802831.28134, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'commentCount': 63, 'markets': [{'id': '516723', 'question': 'Will no Fed rate cuts happen in 2025?', 'conditionId': '0xebfda84c91d3dafde3f49bd132aadc9e762b88023021806e7345cd526fc7e1fa', 'slug': 'will-no-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '88197.5841', 'startDate': '2024-12-29T22:44:16.86863Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there no rate cuts by the Fed\\'s December meeting (including the Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been no rate cuts by then.\\n\\nIf there is a rate cut at any time within 2025, before the statement following the December FOMC meeting is released, this market may immediately resolve to \"No\".\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.145\", \"0.855\"]', 'volume': '1159030.56875', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T19:49:27.907976Z', 'updatedAt': '2025-05-12T19:04:13.514403Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '0', 'groupItemThreshold': '0', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.01, 'orderMinSize': 5, 'volumeNum': 1159030.56875, 'liquidityNum': 88197.5841, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 12027.264241, 'volume1wk': 66388.74835499997, 'volume1mo': 196586.83018700007, 'volume1yr': 1159027.1687499986, 'clobTokenIds': '[\"18020161444416260195750543688224692006431301166904957549340226313298366177208\", \"22815929348267525865179400270560699202940891762662686118783091319501232508008\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 12027.264241, 'volume1wkClob': 66388.74835499997, 'volume1moClob': 196586.83018700007, 'volume1yrClob': 1159027.1687499986, 'volumeClob': 1159030.56875, 'liquidityClob': 88197.5841, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0x4dd53c9b0d616686cea42b92e8886696ea98740d1b249052e6d3b801de11ca77', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:42:48Z', 'cyom': False, 'competitive': 0.8880797495615106, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12269', 'conditionId': '0xebfda84c91d3dafde3f49bd132aadc9e762b88023021806e7345cd526fc7e1fa', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 20, 'startDate': '2024-12-29', 'endDate': '2500-12-31'}], 'rewardsMinSize': 100, 'rewardsMaxSpread': 3.5, 'spread': 0.01, 'oneDayPriceChange': 0.01, 'oneWeekPriceChange': 0.02, 'oneMonthPriceChange': 0.06, 'lastTradePrice': 0.15, 'bestBid': 0.14, 'bestAsk': 0.15, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516730', 'question': 'Will 7 Fed rate cuts happen in 2025?', 'conditionId': '0xf4d03ce9ce65ea06654f23e26dead828005511d65bb650cd5a9dc77891406d12', 'slug': 'will-7-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '127987.54897', 'startDate': '2024-12-29T22:49:01.543705Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are exactly 7 cuts of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 7 rate cuts by then.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 8 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.0195\", \"0.9805\"]', 'volume': '628906.063648', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T20:35:34.291374Z', 'updatedAt': '2025-05-12T19:04:26.173404Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '7 (175 bps)', 'groupItemThreshold': '7', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be07', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.001, 'orderMinSize': 5, 'volumeNum': 628906.063648, 'liquidityNum': 127987.54897, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 13861.776397999998, 'volume1wk': 27588.428574, 'volume1mo': 81826.20628599999, 'volume1yr': 628904.0270370002, 'clobTokenIds': '[\"106637218023173886895550072700357013102189022015797096007920322441434274793343\", \"79328870430805014620288089322067795525620481132773427804769291919755554601870\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 13861.776397999998, 'volume1wkClob': 27588.428574, 'volume1moClob': 81826.20628599999, 'volume1yrClob': 628904.0270370002, 'volumeClob': 628906.063648, 'liquidityClob': 127987.54897, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0xb9c9f7d9d6ffc8464777f8e52c171b21abf668e1c4c5730e157aedbc58089b61', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:47:51Z', 'cyom': False, 'competitive': 0.8124267165713318, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12262', 'conditionId': '0xf4d03ce9ce65ea06654f23e26dead828005511d65bb650cd5a9dc77891406d12', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 20, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.003, 'oneDayPriceChange': -0.006, 'oneWeekPriceChange': -0.0095, 'oneMonthPriceChange': -0.015, 'lastTradePrice': 0.019, 'bestBid': 0.018, 'bestAsk': 0.021, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516724', 'question': 'Will 1 Fed rate cut happen in 2025?', 'conditionId': '0x8e9b6942b4dac3117dadfacac2edb390b6d62d59c14152774bb5fcd983fc134e', 'slug': 'will-1-fed-rate-cut-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '72073.7194', 'startDate': '2024-12-29T22:44:57.641884Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there is exactly 1 cut of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 1 rate cut by then.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 2 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.155\", \"0.845\"]', 'volume': '990938.750393', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T19:53:12.962104Z', 'updatedAt': '2025-05-12T19:04:26.64291Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '1 (25 bps)', 'groupItemThreshold': '1', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be01', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.01, 'orderMinSize': 5, 'volumeNum': 990938.750393, 'liquidityNum': 72073.7194, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 24390.466435, 'volume1wk': 43159.24934599999, 'volume1mo': 156242.97616800002, 'volume1yr': 990922.9703929989, 'clobTokenIds': '[\"15353185604353847122370324954202969073036867278400776447048296624042585335546\", \"26444182150998636640530251053223191773083977191941080891981240618283910212190\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 24390.466435, 'volume1wkClob': 43159.24934599999, 'volume1moClob': 156242.97616800002, 'volume1yrClob': 990922.9703929989, 'volumeClob': 990938.750393, 'liquidityClob': 72073.7194, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0xef6971601b767913c85fd9dd595ea3e73c561df29533e6eb8d9273c0ec10cbb2', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:43:48Z', 'cyom': False, 'competitive': 0.8936350841134023, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12268', 'conditionId': '0x8e9b6942b4dac3117dadfacac2edb390b6d62d59c14152774bb5fcd983fc134e', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 40, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.01, 'oneDayPriceChange': 0.01, 'oneWeekPriceChange': 0.04, 'oneMonthPriceChange': 0.04, 'lastTradePrice': 0.15, 'bestBid': 0.15, 'bestAsk': 0.16, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516725', 'question': 'Will 2 Fed rate cuts happen in 2025?', 'conditionId': '0x05af636e0989accb08334a74f69e5368e0aa28fe498fd16a3ca991e6dc5ae2cc', 'slug': 'will-2-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '56549.1168', 'startDate': '2024-12-29T22:45:22.634712Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are exactly 2 cuts of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 2 rate cuts by then.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 3 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.215\", \"0.785\"]', 'volume': '653223.266363', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T19:54:57.254583Z', 'updatedAt': '2025-05-12T19:04:24.608832Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '2 (50 bps)', 'groupItemThreshold': '2', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be02', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.01, 'orderMinSize': 5, 'volumeNum': 653223.266363, 'liquidityNum': 56549.1168, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 7588.330939000001, 'volume1wk': 32804.462909, 'volume1mo': 139004.83199300003, 'volume1yr': 640017.7519010003, 'clobTokenIds': '[\"11661882248425579028730127122226588074844109517532906275870117904036267401870\", \"61032109452954507190234229613640921045186796600337553837681909605067067778814\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 7588.330939000001, 'volume1wkClob': 32804.462909, 'volume1moClob': 139004.83199300003, 'volume1yrClob': 640017.7519010003, 'volumeClob': 653223.266363, 'liquidityClob': 56549.1168, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0x8b77dbf0e57a1c31eb3dbc187132706ec0cbc98a1f38083017a4366eb4917d0f', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:44:14Z', 'cyom': False, 'competitive': 0.9248768757659137, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12267', 'conditionId': '0x05af636e0989accb08334a74f69e5368e0aa28fe498fd16a3ca991e6dc5ae2cc', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 40, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.01, 'oneDayPriceChange': 0.01, 'oneWeekPriceChange': 0.035, 'oneMonthPriceChange': 0.015, 'lastTradePrice': 0.21, 'bestBid': 0.21, 'bestAsk': 0.22, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516731', 'question': 'Will 6 Fed rate cuts happen in 2025?', 'conditionId': '0x37100ed3560699c48d90a027e65da10a04e395785b598289163e3bbfdaca99e6', 'slug': 'will-6-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '128479.85923', 'startDate': '2024-12-29T22:48:27.776106Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are exactly 6 cuts of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 6 rate cuts by then.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 7 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.0235\", \"0.9765\"]', 'volume': '659252.105993', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T20:36:57.617602Z', 'updatedAt': '2025-05-12T19:04:30.219157Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '6 (150 bps)', 'groupItemThreshold': '6', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be06', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.001, 'orderMinSize': 5, 'volumeNum': 659252.105993, 'liquidityNum': 128479.85923, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 21094.567739, 'volume1wk': 71314.02322599998, 'volume1mo': 137545.225384, 'volume1yr': 657538.3959930005, 'clobTokenIds': '[\"35428628589990747181456921610814206632405028717182760412162159083085892664954\", \"33673334616268013961585301204311121178127515047580027207826322300546567181423\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 21094.567739, 'volume1wkClob': 71314.02322599998, 'volume1moClob': 137545.225384, 'volume1yrClob': 657538.3959930005, 'volumeClob': 659252.105993, 'liquidityClob': 128479.85923, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0x033b2dbd0328eea8a2a302be05efbc501aaf3312be1bec02404fbb49745ec831', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:47:17Z', 'cyom': False, 'competitive': 0.814961221088996, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12261', 'conditionId': '0x37100ed3560699c48d90a027e65da10a04e395785b598289163e3bbfdaca99e6', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 20, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.001, 'oneDayPriceChange': -0.007, 'oneHourPriceChange': -0.001, 'oneWeekPriceChange': -0.0175, 'oneMonthPriceChange': -0.015, 'lastTradePrice': 0.025, 'bestBid': 0.023, 'bestAsk': 0.024, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516726', 'question': 'Will 3 Fed rate cuts happen in 2025?', 'conditionId': '0x6df2f2ca434b5bacaef33d6b24edf42845199f4f794e66580de2d2c880a25275', 'slug': 'will-3-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '74735.2808', 'startDate': '2024-12-29T22:45:47.064873Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are exactly 3 cuts of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 3 rate cuts by then.\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 4 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.185\", \"0.815\"]', 'volume': '692523.839503', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T19:57:11.618587Z', 'updatedAt': '2025-05-12T19:04:23.898644Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '3 (75 bps)', 'groupItemThreshold': '3', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be03', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.01, 'orderMinSize': 5, 'volumeNum': 692523.839503, 'liquidityNum': 74735.2808, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 16100.571577, 'volume1wk': 36193.11846599999, 'volume1mo': 109932.32376400002, 'volume1yr': 692523.8395030003, 'clobTokenIds': '[\"17601770442239563289082275181138749951422899442850916335476881677007065139739\", \"39979393291433838641824861631885750592113619894259619599511650636783179688654\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 16100.571577, 'volume1wkClob': 36193.11846599999, 'volume1moClob': 109932.32376400002, 'volume1yrClob': 692523.8395030003, 'volumeClob': 692523.839503, 'liquidityClob': 74735.2808, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0x9cf39e79b6cd47e9fabcafcef10d0f49528ca3328caf091ff3b696ed1258d5be', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:44:34Z', 'cyom': False, 'competitive': 0.9097318565352862, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12266', 'conditionId': '0x6df2f2ca434b5bacaef33d6b24edf42845199f4f794e66580de2d2c880a25275', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 40, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.01, 'oneDayPriceChange': -0.005, 'oneWeekPriceChange': -0.015, 'lastTradePrice': 0.17, 'bestBid': 0.18, 'bestAsk': 0.19, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516727', 'question': 'Will 4 Fed rate cuts happen in 2025?', 'conditionId': '0xc2846f35e85eb09a094edbd4e93e345d3c682dc0436615adc27122222fccbd81', 'slug': 'will-4-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '73255.9678', 'startDate': '2024-12-29T22:46:07.293351Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are exactly 4 cuts of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 4 rate cuts by then.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 5 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.105\", \"0.895\"]', 'volume': '855214.545982', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T19:58:26.387182Z', 'updatedAt': '2025-05-12T19:04:26.620202Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '4 (100 bps)', 'groupItemThreshold': '4', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be04', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.01, 'orderMinSize': 5, 'volumeNum': 855214.545982, 'liquidityNum': 73255.9678, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 57545.09, 'volume1wk': 84984.417292, 'volume1mo': 239350.17891100008, 'volume1yr': 855214.5459819995, 'clobTokenIds': '[\"89004595068776945908481855030043950109477136860300352348370395226706216458498\", \"66497712136360061394637670796773281770486705493678163278744913561923724550407\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 57545.09, 'volume1wkClob': 84984.417292, 'volume1moClob': 239350.17891100008, 'volume1yrClob': 855214.5459819995, 'volumeClob': 855214.545982, 'liquidityClob': 73255.9678, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0xdf1c35d58be927accc754bf40f80fd470f1cdc180a9b7a18d76e33eb184cd976', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:44:56Z', 'cyom': False, 'competitive': 0.865033195648883, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12265', 'conditionId': '0xc2846f35e85eb09a094edbd4e93e345d3c682dc0436615adc27122222fccbd81', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 30, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.01, 'oneDayPriceChange': -0.02, 'oneWeekPriceChange': -0.065, 'oneMonthPriceChange': -0.045, 'lastTradePrice': 0.1, 'bestBid': 0.1, 'bestAsk': 0.11, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516728', 'question': 'Will 5 Fed rate cuts happen in 2025?', 'conditionId': '0x6ee22365b6602d928aa7136f549cc0d718bb16b044a6d15191041b84b5f1f43d', 'slug': 'will-5-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '98301.0721', 'startDate': '2024-12-29T22:47:57.16237Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': 'The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are exactly 5 cuts of 25 basis points by the Fed\\'s December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nThis market may resolve to \"Yes\" immediately after the statement from the Fed\\'s December 2025 meeting has been released if there has been exactly 5 rate cuts by then.\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each). If there are 6 or more rate cuts at any point before this market\\'s resolution date, this market will resolve to \"No\".\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.', 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.0405\", \"0.9595\"]', 'volume': '677519.504874', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T19:59:42.523614Z', 'updatedAt': '2025-05-12T19:04:23.347547Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '5 (125 bps)', 'groupItemThreshold': '5', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be05', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.001, 'orderMinSize': 5, 'volumeNum': 677519.504874, 'liquidityNum': 98301.0721, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 36632.817141, 'volume1wk': 71627.3626, 'volume1mo': 128518.206443, 'volume1yr': 677519.5048740002, 'clobTokenIds': '[\"302273160494790559492931429044277112497487176914839291053945756072421867571\", \"71168072025438256100937333610884784661496543167790290367141049156834121296266\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 36632.817141, 'volume1wkClob': 71627.3626, 'volume1moClob': 128518.206443, 'volume1yrClob': 677519.5048740002, 'volumeClob': 677519.504874, 'liquidityClob': 98301.0721, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0x47f7b59cf1fef3097e5d68a70c83b82120748bc17b2426fb9e29396134c34c93', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:46:10Z', 'cyom': False, 'competitive': 0.8256682081204055, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12264', 'conditionId': '0x6ee22365b6602d928aa7136f549cc0d718bb16b044a6d15191041b84b5f1f43d', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 20, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.003, 'oneDayPriceChange': -0.0135, 'oneHourPriceChange': -0.0005, 'oneWeekPriceChange': -0.043, 'oneMonthPriceChange': -0.061, 'lastTradePrice': 0.042, 'bestBid': 0.039, 'bestAsk': 0.042, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}, {'id': '516729', 'question': 'Will 8+ Fed rate cuts happen in 2025?', 'conditionId': '0x12b6268efb832fe64bb746b9f50a51245b761d6b170e172b3cd81a7c4f39432b', 'slug': 'will-8plus-fed-rate-cuts-happen-in-2025', 'resolutionSource': '', 'endDate': '2025-12-10T12:00:00Z', 'liquidity': '83251.13214', 'startDate': '2024-12-29T22:49:51.6373Z', 'image': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'icon': 'https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg', 'description': \"The FED interest rates are defined in this market by the upper bound of the target federal funds range. The decisions on the target federal fund range are made by the Federal Open Market Committee (FOMC) meetings.\\n\\nThis market will resolve to “Yes” if the there are 8 or more cuts of 25 basis points by the Fed's December meeting (including any cuts made during Dec meeting). Otherwise, this market will resolve to “No.”\\n\\nFor example, if the FED cuts rates by 50 bps after a meeting, it would be considered 2 cuts (of 25 bps each).\\n\\nNote that cuts between 1-24 bps (inclusive) will also be considered 1 rate cut.\\n\\nThe resolution source for this market will be FOMC statements after meetings scheduled in 2025 according to the official calendar: https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm. The level and change of the target federal funds rate is also published at the official website of the Federal Reserve at https://www.federalreserve.gov/monetarypolicy/openmarket.htm.\", 'outcomes': '[\"Yes\", \"No\"]', 'outcomePrices': '[\"0.059\", \"0.941\"]', 'volume': '625481.33498', 'active': True, 'closed': False, 'marketMakerAddress': '', 'createdAt': '2024-12-29T20:01:42.662085Z', 'updatedAt': '2025-05-12T19:04:15.646961Z', 'new': False, 'featured': False, 'submitted_by': '0x91430CaD2d3975766499717fA0D66A78D814E5c5', 'archived': False, 'resolvedBy': '0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d', 'restricted': True, 'groupItemTitle': '8 or more (200+ bps)', 'groupItemThreshold': '8', 'questionID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be08', 'enableOrderBook': True, 'orderPriceMinTickSize': 0.001, 'orderMinSize': 5, 'volumeNum': 625481.33498, 'liquidityNum': 83251.13214, 'endDateIso': '2025-12-10', 'startDateIso': '2024-12-29', 'hasReviewedDates': True, 'volume24hr': 352.803341, 'volume1wk': 52247.89590500001, 'volume1mo': 127091.66394399999, 'volume1yr': 625481.3349800002, 'clobTokenIds': '[\"61673387045681238454585997121170806826401631642653090831500827557099057497566\", \"75673530794317709253317435585138828689432689207295322743064114581203964183879\"]', 'umaBond': '500', 'umaReward': '5', 'volume24hrClob': 352.803341, 'volume1wkClob': 52247.89590500001, 'volume1moClob': 127091.66394399999, 'volume1yrClob': 625481.3349800002, 'volumeClob': 625481.33498, 'liquidityClob': 83251.13214, 'acceptingOrders': True, 'negRisk': True, 'negRiskMarketID': '0x1bdcc22f99efd4a0af525806c64f7e6ee0a1640517b1d0a4a731367b6554be00', 'negRiskRequestID': '0xc0f1a3e1cf79a9eaa1b2f4a6ccb3fc77549b736876dd82aadda2e1c483493a6e', 'ready': False, 'funded': False, 'acceptingOrdersTimestamp': '2024-12-29T22:48:41Z', 'cyom': False, 'competitive': 0.8371836806110771, 'pagerDutyNotificationEnabled': False, 'approved': True, 'clobRewards': [{'id': '12263', 'conditionId': '0x12b6268efb832fe64bb746b9f50a51245b761d6b170e172b3cd81a7c4f39432b', 'assetAddress': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', 'rewardsAmount': 0, 'rewardsDailyRate': 20, 'startDate': '2024-12-28', 'endDate': '2500-12-31'}], 'rewardsMinSize': 200, 'rewardsMaxSpread': 3.5, 'spread': 0.004, 'oneDayPriceChange': 0.0015, 'oneWeekPriceChange': -0.0155, 'oneMonthPriceChange': -0.037, 'lastTradePrice': 0.061, 'bestBid': 0.057, 'bestAsk': 0.061, 'automaticallyActive': True, 'clearBookOnStart': True, 'seriesColor': '', 'showGmpSeries': False, 'showGmpOutcome': False, 'manualActivation': False, 'negRiskOther': False, 'umaResolutionStatuses': '[]', 'pendingDeployment': False, 'deploying': False}], 'tags': [{'id': '100196', 'label': 'Fed Rates', 'slug': 'fed-rates', 'forceShow': True, 'updatedAt': '2024-04-10T13:45:50.469564Z'}, {'id': '107', 'label': 'Business', 'slug': 'business', 'forceShow': False, 'publishedAt': '2023-11-02 21:20:37.48+00', 'createdAt': '2023-11-02T21:20:37.488Z', 'updatedAt': '2024-07-05T21:07:24.910181Z'}, {'id': '101588', 'label': '2025 Predictions', 'slug': '2025-predictions', 'forceShow': False, 'createdAt': '2024-12-30T20:11:13.144816Z', 'updatedAt': '2024-12-30T20:19:11.195161Z'}, {'id': '101800', 'label': 'Economic Policy', 'slug': 'economic-policy', 'forceShow': False, 'createdAt': '2025-02-06T18:05:50.554703Z'}], 'cyom': False, 'showAllOutcomes': True, 'showMarketImages': False, 'enableNegRisk': True, 'automaticallyActive': True, 'gmpChartMode': 'default', 'negRiskAugmented': False, 'featuredOrder': 10, 'pendingDeployment': False, 'deploying': False}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = f\"{base_url}{slug}\" #combine the slug and the gamme endpoint\n",
+    "response = requests.get(url)\n",
+    "if response.status_code != 200:\n",
+    "    print(f\"Failed to retrieve data for slug  {slug}\")\n",
+    "\n",
+    "data = response.json() #List of markets associated with the event we entered earlier\n",
+    "\n",
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You'll see that the output of the above code is a list of JSON objects. Because we sent a specefic slug it was only 1 result thus 1 JSON object returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== MARKET INFO ===\n",
+      "ID: 16085\n",
+      "Title: How many Fed rate cuts in 2025?\n",
+      "Ticker: how-many-fed-rate-cuts-in-2025\n",
+      "Slug: how-many-fed-rate-cuts-in-2025\n",
+      "Description:\n",
+      "This is a market group over how many Fed rate cuts will happen in 2025.\n",
+      "\n",
+      "Start Date: 2024-12-29T22:50:43.348587Z\n",
+      "End Date: 2025-12-31T12:00:00Z\n",
+      "Active: True\n",
+      "Closed: False\n",
+      "Restricted: True\n",
+      "Liquidity: 802831.28134\n",
+      "Volume: 6942089.980486\n",
+      "Volume (24hr): 189593.687811\n",
+      "Volume (1wk): 486307.70667299995\n",
+      "Volume (1mo): 1316098.44308\n",
+      "Competitive Score: 0.9248768757659137\n",
+      "Image URL: https://polymarket-upload.s3.us-east-2.amazonaws.com/how-many-fed-rate-cuts-in-2025-9qstZkSL1dn0.jpg\n",
+      "\n",
+      "=== TAGS ===\n",
+      "- Fed Rates\n",
+      "- Business\n",
+      "- 2025 Predictions\n",
+      "- Economic Policy\n",
+      "=== TOKEN IDs ===\n",
+      "Market ID 516723 Token IDs:\n",
+      "- 18020161444416260195750543688224692006431301166904957549340226313298366177208\n",
+      "- 22815929348267525865179400270560699202940891762662686118783091319501232508008\n",
+      "Market ID 516730 Token IDs:\n",
+      "- 106637218023173886895550072700357013102189022015797096007920322441434274793343\n",
+      "- 79328870430805014620288089322067795525620481132773427804769291919755554601870\n",
+      "Market ID 516724 Token IDs:\n",
+      "- 15353185604353847122370324954202969073036867278400776447048296624042585335546\n",
+      "- 26444182150998636640530251053223191773083977191941080891981240618283910212190\n",
+      "Market ID 516725 Token IDs:\n",
+      "- 11661882248425579028730127122226588074844109517532906275870117904036267401870\n",
+      "- 61032109452954507190234229613640921045186796600337553837681909605067067778814\n",
+      "Market ID 516731 Token IDs:\n",
+      "- 35428628589990747181456921610814206632405028717182760412162159083085892664954\n",
+      "- 33673334616268013961585301204311121178127515047580027207826322300546567181423\n",
+      "Market ID 516726 Token IDs:\n",
+      "- 17601770442239563289082275181138749951422899442850916335476881677007065139739\n",
+      "- 39979393291433838641824861631885750592113619894259619599511650636783179688654\n",
+      "Market ID 516727 Token IDs:\n",
+      "- 89004595068776945908481855030043950109477136860300352348370395226706216458498\n",
+      "- 66497712136360061394637670796773281770486705493678163278744913561923724550407\n",
+      "Market ID 516728 Token IDs:\n",
+      "- 302273160494790559492931429044277112497487176914839291053945756072421867571\n",
+      "- 71168072025438256100937333610884784661496543167790290367141049156834121296266\n",
+      "Market ID 516729 Token IDs:\n",
+      "- 61673387045681238454585997121170806826401631642653090831500827557099057497566\n",
+      "- 75673530794317709253317435585138828689432689207295322743064114581203964183879\n",
+      "\n",
+      "=== SERIES ===\n",
+      "\n",
+      "=== NESTED MARKETS ===\n",
+      "Market ID: 516723\n",
+      "Question: Will no Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.145', '0.855']\n",
+      "Volume: 1159030.56875\n",
+      "Liquidity: 88197.5841\n",
+      "Best Bid: 0.14, Best Ask: 0.15\n",
+      "Last Trade Price: 0.15\n",
+      "----\n",
+      "Market ID: 516730\n",
+      "Question: Will 7 Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.0195', '0.9805']\n",
+      "Volume: 628906.063648\n",
+      "Liquidity: 127987.54897\n",
+      "Best Bid: 0.018, Best Ask: 0.021\n",
+      "Last Trade Price: 0.019\n",
+      "----\n",
+      "Market ID: 516724\n",
+      "Question: Will 1 Fed rate cut happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.155', '0.845']\n",
+      "Volume: 990938.750393\n",
+      "Liquidity: 72073.7194\n",
+      "Best Bid: 0.15, Best Ask: 0.16\n",
+      "Last Trade Price: 0.15\n",
+      "----\n",
+      "Market ID: 516725\n",
+      "Question: Will 2 Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.215', '0.785']\n",
+      "Volume: 653223.266363\n",
+      "Liquidity: 56549.1168\n",
+      "Best Bid: 0.21, Best Ask: 0.22\n",
+      "Last Trade Price: 0.21\n",
+      "----\n",
+      "Market ID: 516731\n",
+      "Question: Will 6 Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.0235', '0.9765']\n",
+      "Volume: 659252.105993\n",
+      "Liquidity: 128479.85923\n",
+      "Best Bid: 0.023, Best Ask: 0.024\n",
+      "Last Trade Price: 0.025\n",
+      "----\n",
+      "Market ID: 516726\n",
+      "Question: Will 3 Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.185', '0.815']\n",
+      "Volume: 692523.839503\n",
+      "Liquidity: 74735.2808\n",
+      "Best Bid: 0.18, Best Ask: 0.19\n",
+      "Last Trade Price: 0.17\n",
+      "----\n",
+      "Market ID: 516727\n",
+      "Question: Will 4 Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.105', '0.895']\n",
+      "Volume: 855214.545982\n",
+      "Liquidity: 73255.9678\n",
+      "Best Bid: 0.1, Best Ask: 0.11\n",
+      "Last Trade Price: 0.1\n",
+      "----\n",
+      "Market ID: 516728\n",
+      "Question: Will 5 Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.0405', '0.9595']\n",
+      "Volume: 677519.504874\n",
+      "Liquidity: 98301.0721\n",
+      "Best Bid: 0.039, Best Ask: 0.042\n",
+      "Last Trade Price: 0.042\n",
+      "----\n",
+      "Market ID: 516729\n",
+      "Question: Will 8+ Fed rate cuts happen in 2025?\n",
+      "Outcomes: ['Yes', 'No']\n",
+      "Outcome Prices: ['0.059', '0.941']\n",
+      "Volume: 625481.33498\n",
+      "Liquidity: 83251.13214\n",
+      "Best Bid: 0.057, Best Ask: 0.061\n",
+      "Last Trade Price: 0.061\n",
+      "----\n"
+     ]
+    }
+   ],
+   "source": [
+    "market_info = data[0]\n",
+    "\n",
+    "def print_market_info(market):\n",
+    "    print(\"=== MARKET INFO ===\")\n",
+    "    print(f\"ID: {market['id']}\")\n",
+    "    print(f\"Title: {market['title']}\")\n",
+    "    print(f\"Ticker: {market['ticker']}\")\n",
+    "    print(f\"Slug: {market['slug']}\")\n",
+    "    print(f\"Description:\\n{market['description'].strip()}\\n\")\n",
+    "    print(f\"Start Date: {market['startDate']}\")\n",
+    "    print(f\"End Date: {market['endDate']}\")\n",
+    "    print(f\"Active: {market['active']}\")\n",
+    "    print(f\"Closed: {market['closed']}\")\n",
+    "    print(f\"Restricted: {market['restricted']}\")\n",
+    "    print(f\"Liquidity: {market['liquidity']}\")\n",
+    "    print(f\"Volume: {market['volume']}\")\n",
+    "    print(f\"Volume (24hr): {market['volume24hr']}\")\n",
+    "    print(f\"Volume (1wk): {market['volume1wk']}\")\n",
+    "    print(f\"Volume (1mo): {market['volume1mo']}\")\n",
+    "    print(f\"Competitive Score: {market['competitive']}\")\n",
+    "    print(f\"Image URL: {market['image']}\")\n",
+    "    print(\"\\n=== TAGS ===\")\n",
+    "    for tag in market.get(\"tags\", []):\n",
+    "        print(f\"- {tag['label']}\")\n",
+    "\n",
+    "    print(\"=== TOKEN IDs ===\")\n",
+    "    for mkt in market_info.get(\"markets\", []):\n",
+    "        token_ids = json.loads(mkt.get(\"clobTokenIds\", \"[]\"))\n",
+    "        print(f\"Market ID {mkt['id']} Token IDs:\")\n",
+    "        for tid in token_ids:\n",
+    "            print(f\"- {tid}\")\n",
+    "\n",
+    "    print(\"\\n=== SERIES ===\")\n",
+    "    for series in market.get(\"series\", []):\n",
+    "        print(f\"Title: {series['title']}, Volume: {series['volume']}, Liquidity: {series['liquidity']}\")\n",
+    "\n",
+    "    print(\"\\n=== NESTED MARKETS ===\")\n",
+    "    for mkt in market.get(\"markets\", []):\n",
+    "        print(f\"Market ID: {mkt['id']}\")\n",
+    "        print(f\"Question: {mkt['question']}\")\n",
+    "        print(f\"Outcomes: {json.loads(mkt['outcomes'])}\")\n",
+    "        print(f\"Outcome Prices: {json.loads(mkt['outcomePrices'])}\")\n",
+    "        print(f\"Volume: {mkt['volume']}\")\n",
+    "        print(f\"Liquidity: {mkt['liquidity']}\")\n",
+    "        print(f\"Best Bid: {mkt['bestBid']}, Best Ask: {mkt['bestAsk']}\")\n",
+    "        print(f\"Last Trade Price: {mkt['lastTradePrice']}\")\n",
+    "        print(\"----\")\n",
+    "\n",
+    "print_market_info(market_info)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/interactive_notebooks/yourFirstTrade.ipynb
+++ b/examples/interactive_notebooks/yourFirstTrade.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "General imports that we'll need\n",
+    "I highly reccomend creating a virtual enviroment for all Polymarket related items as some aspect of the client require specefic versions of tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from py_clob_client.client import ClobClient\n",
+    "from py_clob_client.clob_types import OrderArgs, PartialCreateOrderOptions, MarketOrderArgs, OrderScoringParams, OpenOrderParams\n",
+    "from py_clob_client.order_builder.constants import BUY, SELL\n",
+    "from py_clob_client.exceptions import PolyApiException\n",
+    "from math import floor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets set up the variables we'll need to initialize the client. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here are what the following variables represent:\n",
+    "funder: The Polymarket address associated with the browser wallet login OR the email login.\n",
+    "host: the Polymarket CLOB endpoint https://clob.polymarket.com\n",
+    "key: The private key exported from Magic that is associated with the account OR The private key exported from the Browser Wallet that is associated with the account\n",
+    "    If you use the email login you need to visit https://reveal.magic.link/\n",
+    "    If you use metamask/web3 login you need to export the private key from that application. \n",
+    "chain_id: For the majority of use cases this can be safely set to 137(Polygon Mainnet)\n",
+    "signature_type: Again, generally this will be 1\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "funder = \"\" #The Funder is the adress as seen on your Polymarket profile.\n",
+    "host = \"https://clob.polymarket.com\"\n",
+    "key = \"\" #This is your private key. See above for details \n",
+    "chain_id = 137\n",
+    "signature_type = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = ClobClient(\n",
+    "host,               # the polymarket host\n",
+    "key=key,            # your private key exported from magic/polymarket\n",
+    "chain_id=chain_id,  # 137\n",
+    "signature_type=1,   # this type of config requires this signature type\n",
+    "funder=funder) # this is your polymarket public address (where you send the usdc)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the documentation you'll find the ability to export, save or generate API creds. This is generally unnecesary but nice to have. The below code handles creating new keys if neccesary or using existing ones if keys do exist. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.set_api_creds(client.create_or_derive_api_creds())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to follow DRY(DON'T REPEAT YOURSELF) principles lets create a simple function that can handle Buying and Selling for us. \n",
+    "The function takes an action \"BUY\" or \"SELL\", a TOKENId and the number of shares to buy. To find a token ID please see the \"Market Info\" Notebook. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#In production you absolutely need try/catch blocks here but for the purposes of simplicity we're ignoring that neccesity for now. \n",
+    "def buy_sell_limit_order(action: str, tokenID: str, numShares: int, price: float = .99, neg_risk_status: bool = False):\n",
+    "    if action == 'BUY':\n",
+    "        order_args = OrderArgs(\n",
+    "            token_id=tokenID,\n",
+    "            side='BUY',\n",
+    "            size=floor(numShares),\n",
+    "            price=price\n",
+    "            )\n",
+    "        signed_order = client.create_order(order_args, PartialCreateOrderOptions(neg_risk=neg_risk_status))\n",
+    "    elif action == 'SELL':\n",
+    "        order_args = OrderArgs(\n",
+    "            token_id=tokenID,\n",
+    "            side='SELL',\n",
+    "            price=price,#hardcode for sell\n",
+    "            size=numShares #will be shares in this case\n",
+    "                        )\n",
+    "        signed_order = client.create_order(order_args, PartialCreateOrderOptions(neg_risk=neg_risk_status))\n",
+    "    else: \n",
+    "        print(f\"Invalid action. Action recieved: {action}\")\n",
+    "        return\n",
+    "\n",
+    "\n",
+    "    #NotEnough balance/allowance can mean that you dont have enough shares \n",
+    "    #invalid sig can mean its negrisk or your funder is \n",
+    "    resp = client.post_order(signed_order)\n",
+    "    print(f\"Order Response: {resp}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Couple notes on the above function. These are limit orders so you'll need to specify the price you're willing to buy or sell at and the number of shares to buy/sell at theat price. You also need to specify rather a market is negative risk or not. Check the docs for details on that but in basic terms if there are multiple mutually exclusive outcomes(2+) the market is neg_risk. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Order Response: {'errorMsg': '', 'orderID': '0xb234bd04fe355e6f0579069434b1ff0f172121cccff13f569f3e01d3318faa8a', 'takingAmount': '', 'makingAmount': '', 'status': 'live', 'transactionsHashes': None, 'success': True}\n"
+     ]
+    }
+   ],
+   "source": [
+    "buy_sell_limit_order('BUY',\"55339638397443112919791846485253629869798811464400272253569648598507361954673\",5,price=.01,neg_risk_status=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "firecontrol",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Overview
Added some very user friendly Jupyter notebooks. 

## Description
In the /examples folder I added 2 Jupyter/interactive notebooks that hand walk users through the most crucial tasks.
1. Placing a limit limit buy or limit sell. With background on how to get the required information you need.
2. Extracting data from the Gamma API based on the slug


<!-- Check one of the boxes below, and add additional information as necessary. -->

- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [ ] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ x] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

## Status

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation/changelog as needed.
- [ ] Verify all tests run correctly in CI and pass.
- [x ] Ready for review/merge.
