### PR TITLE
Fix: Enum Inheritance for OrderType/AssetType

### DIFF
--- a/py_clob_client/clob_types.py
+++ b/py_clob_client/clob_types.py
@@ -2,6 +2,7 @@ from typing import Any
 from dataclasses import dataclass, asdict
 from json import dumps
 from typing import Literal, Optional
+from enum import Enum
 from py_order_utils.model import (
     SignedOrder,
 )
@@ -9,7 +10,7 @@ from py_order_utils.model import (
 from .constants import ZERO_ADDRESS
 
 
-class OrderType(enumerate):
+class OrderType(str, Enum):
     GTC = "GTC"
     FOK = "FOK"
     GTD = "GTD"
@@ -177,7 +178,7 @@ class OrderBookSummary:
         return dumps(self.__dict__, separators=(",", ":"))
 
 
-class AssetType(enumerate):
+class AssetType(str, Enum):
     COLLATERAL = "COLLATERAL"
     CONDITIONAL = "CONDITIONAL"
 

--- a/py_clob_client/http_helpers/helpers.py
+++ b/py_clob_client/http_helpers/helpers.py
@@ -144,7 +144,7 @@ def add_balance_allowance_params_to_url(
     if params:
         url = url + "?"
         if params.asset_type:
-            url = build_query_params(url, "asset_type", params.asset_type.__str__())
+            url = build_query_params(url, "asset_type", params.asset_type.value)
         if params.token_id:
             url = build_query_params(url, "token_id", params.token_id)
         if params.signature_type is not None:


### PR DESCRIPTION
# Overview

Fixes incorrect enum inheritance - `OrderType` and `AssetType` inherited from `enumerate` (built-in function) instead of `Enum` class. Caused type checker errors and broken enum functionality. I noticed this after it was flagged by my type checker when building something downstream.

## Changes

1. Added `from enum import Enum` to `py_clob_client/clob_types.py`
2. `OrderType(enumerate):` → `OrderType(str, Enum):` (line 13)
3. `AssetType(enumerate):` → `AssetType(str, Enum):` (line 181)
4. `helpers.py:147` now uses `.value` for URL query params

## Technical

`enumerate` is a function, not a class. Multiple inheritance from `str` and `Enum` provides:
- Proper type checking/IDE support
- Auto JSON serialization
- Natural string operations
- Full backward compatibility

URL builder needed update: `__str__()` on proper Enum returns `"AssetType.COLLATERAL"` not `"COLLATERAL"`. Now use `.value` to extract string.

Note: `StrEnum` exists (Python 3.11+) but `str, Enum` ensures older version support.

## Testing

`pytest -s` or `make test` - all 82 tests pass locally

## Type

Bug fix/behavior correction

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [x] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [x] Add tests to cover changes as needed. (NA)
- [x] Update documentation/changelog as needed. (NA)
- [x] Verify all tests run correctly in CI and pass. (Tests all passing locally)
- [x] Ready for review/merge.
