### PR TITLE
fix: rounding

### DIFF
--- a/py_clob_client/order_builder/helpers.py
+++ b/py_clob_client/order_builder/helpers.py
@@ -3,17 +3,17 @@ from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_UP, ROUND_CEILING
 
 def round_down(x: float, sig_digits: int) -> float:
     exp = Decimal(1).scaleb(-sig_digits)
-    return float(Decimal((str(x))).quantize(exp=exp, rounding=ROUND_FLOOR))
+    return float(Decimal(str(x)).quantize(exp=exp, rounding=ROUND_FLOOR))
 
 
 def round_normal(x: float, sig_digits: int) -> float:
     exp = Decimal(1).scaleb(-sig_digits)
-    return float(Decimal((str(x))).quantize(exp=exp, rounding=ROUND_HALF_UP))
+    return float(Decimal(str(x)).quantize(exp=exp, rounding=ROUND_HALF_UP))
 
 
 def round_up(x: float, sig_digits: int) -> float:
     exp = Decimal(1).scaleb(-sig_digits)
-    return float(Decimal((str(x))).quantize(exp=exp, rounding=ROUND_CEILING))
+    return float(Decimal(str(x)).quantize(exp=exp, rounding=ROUND_CEILING))
 
 
 def to_token_decimals(x: float) -> int:


### PR DESCRIPTION
## Overview
I noticed I was placing an order with size 9.53 and I was getting back one with size 9.52.
Turns out it was due to round_down(9.53, 2) = 9.52 in order_builder/helpers.

## Description

- Changed round_up and round_down from floor/ceil to Decimal.quantize to eliminate binary float errors and ensure the expected base-10 behavior (e.g. round_down(9.53, 2) = 9.53).
- Changed round_normal and to_token_decimals for style consistency with the above changes.

## Types of changes

- [x] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->

## Status

- [x] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [x] Add tests to cover changes as needed. (NA)
- [x] Update documentation/changelog as needed. (NA)
- [x] Verify all tests run correctly in CI and pass. - all 82 tests pass
- [x] Ready for review/merge.

same "Found 108 errors in 10 files (checked 21 source files)" linting errors as py-clob-client 0.25.0.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace float-based floor/ceil/round with Decimal.quantize for accurate base-10 rounding in helpers, and simplify token decimal conversion.
> 
> - **Rounding logic** (`py_clob_client/order_builder/helpers.py`):
>   - Replace float-based `floor`/`ceil`/`round` with `Decimal.quantize` using `ROUND_FLOOR`, `ROUND_HALF_UP`, and `ROUND_CEILING` in `round_down`, `round_normal`, and `round_up`.
>   - Update `to_token_decimals` to compute `6`-decimal token amounts via `Decimal(...).quantize(exp=1, rounding=ROUND_HALF_UP)`.
>   - Keep `decimal_places` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40567698b615a4c28d430ea46452f5d6809397bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->