### PR TITLE
chore: fix typo across codebase

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -265,7 +265,7 @@ class ClobClient:
 
     def get_closed_only_mode(self):
         """
-        Gets the closed only mode flag for thsi address
+        Gets the closed only mode flag for this address
         Level 2 Auth required
         """
         self.assert_level_2_auth()


### PR DESCRIPTION
Fixed typo across codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a docstring typo in `ClobClient.get_closed_only_mode` ("thsi" → "this").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8134a7749c4d15ea8f05c88e0c888ac3016dff26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->