### PR TITLE
fix: Use canonical JSON serialization in HMAC signature

### DIFF
--- a/py_clob_client/signing/hmac.py
+++ b/py_clob_client/signing/hmac.py
@@ -1,6 +1,7 @@
 import hmac
 import hashlib
 import base64
+import json
 
 
 def build_hmac_signature(
@@ -12,9 +13,8 @@ def build_hmac_signature(
     base64_secret = base64.urlsafe_b64decode(secret)
     message = str(timestamp) + str(method) + str(requestPath)
     if body:
-        # NOTE: Necessary to replace single quotes with double quotes
-        # to generate the same hmac message as go and typescript
-        message += str(body).replace("'", '"')
+        # Use canonical JSON serialization for cross-language consistency
+        message += json.dumps(body, separators=(",", ":"))
 
     h = hmac.new(base64_secret, bytes(message, "utf-8"), hashlib.sha256)
 


### PR DESCRIPTION
## Problem
The Python client was throwing `PolyApiException[status_code=401, error_message={'error': 'Unauthorized/Invalid api key'}]` when calling `post_order()`, even with valid API credentials.

## Root Cause
The HMAC signature was computed using Python's `str()` representation of the body dictionary, which created non-canonical JSON that didn't match the canonical JSON used by Go/TypeScript servers, causing signature validation to fail.

## Solution
Changed to use canonical JSON serialization with `json.dumps(body, separators=(',', ':'))` to ensure compact, canonical JSON that matches across all languages.

## Changes
- **File**: `py_clob_client/signing/hmac.py`
- Added `import json`
- Replaced `str(body).replace("'", '"')` with `json.dumps(body, separators=(',', ':'))`

## Testing
✅ Successfully tested with signature_type=1 (Email/Magic wallet proxy)
✅ Order posting now works - placed and filled order successfully
✅ Order response: `{'status': 'matched', 'success': True}`

This is the same fix confirmed working by multiple users in related discussions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch HMAC body serialization to canonical JSON (json.dumps with compact separators) to ensure cross-language signature consistency.
> 
> - **Signing**:
>   - Update `build_hmac_signature` in `py_clob_client/signing/hmac.py` to serialize `body` with `json.dumps(..., separators=(",", ":"))` for canonical JSON.
>   - Add `import json` and remove reliance on Python `str()` representation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e87b8afb0e90542eb600a269565c8700db80d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->