### PR TITLE
Fix: regenerate HMAC headers for each pagination request

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -304,7 +304,9 @@ class ClobClient:
         request_args = RequestArgs(method="POST", request_path=CREATE_READONLY_API_KEY)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
 
-        response = post("{}{}".format(self.host, CREATE_READONLY_API_KEY), headers=headers)
+        response = post(
+            "{}{}".format(self.host, CREATE_READONLY_API_KEY), headers=headers
+        )
         try:
             return ReadonlyApiKeyResponse(api_key=response["apiKey"])
         except:
@@ -699,12 +701,14 @@ class ClobClient:
         Requires Level 2 authentication
         """
         self.assert_level_2_auth()
-        request_args = RequestArgs(method="GET", request_path=ORDERS)
-        headers = create_level_2_headers(self.signer, self.creds, request_args)
 
         results = []
         next_cursor = next_cursor if next_cursor is not None else "MA=="
         while next_cursor != END_CURSOR:
+            # Generate fresh headers for each request to avoid HMAC signature expiry
+            request_args = RequestArgs(method="GET", request_path=ORDERS)
+            headers = create_level_2_headers(self.signer, self.creds, request_args)
+
             url = add_query_open_orders_params(
                 "{}{}".format(self.host, ORDERS), params, next_cursor
             )
@@ -752,12 +756,14 @@ class ClobClient:
         Requires Level 2 authentication
         """
         self.assert_level_2_auth()
-        request_args = RequestArgs(method="GET", request_path=TRADES)
-        headers = create_level_2_headers(self.signer, self.creds, request_args)
 
         results = []
         next_cursor = next_cursor if next_cursor is not None else "MA=="
         while next_cursor != END_CURSOR:
+            # Generate fresh headers for each request to avoid HMAC signature expiry
+            request_args = RequestArgs(method="GET", request_path=TRADES)
+            headers = create_level_2_headers(self.signer, self.creds, request_args)
+
             url = add_query_trade_params(
                 "{}{}".format(self.host, TRADES), params, next_cursor
             )
@@ -983,14 +989,15 @@ class ClobClient:
         """
         self.assert_builder_auth()
 
-        request_args = RequestArgs(method="GET", request_path=GET_BUILDER_TRADES)
-        headers = self._get_builder_headers(
-            request_args.method, request_args.request_path, request_args.body
-        )
-
         results = []
         next_cursor = next_cursor if next_cursor is not None else "MA=="
         while next_cursor != END_CURSOR:
+            # Generate fresh headers for each request to avoid signature expiry
+            request_args = RequestArgs(method="GET", request_path=GET_BUILDER_TRADES)
+            headers = self._get_builder_headers(
+                request_args.method, request_args.request_path, request_args.body
+            )
+
             url = add_query_trade_params(
                 "{}{}".format(self.host, GET_BUILDER_TRADES), params, next_cursor
             )


### PR DESCRIPTION
## Overview

Fix HMAC signature expiry during pagination in `get_trades()`, `get_orders()`, and `get_builder_trades()` methods.

## Description

The paginated methods generate HMAC authentication headers **once before the pagination loop**, then reuse them for all subsequent requests. Since HMAC signatures include a timestamp and have a server-side validity window (~60 seconds), this causes **401 Unauthorized errors** when:

- Users have many trades/orders requiring multiple pagination requests
- The total fetch time exceeds the HMAC signature validity period

**Example:** A user with 70,000+ trades needs ~230 pagination requests. Using the same headers for all requests eventually causes the signature to expire mid-pagination.

**Fix:** Move `create_level_2_headers()` call inside the `while` loop so each pagination request gets fresh headers with a current timestamp.

## Testing

- [x] Tested with account having 69,000+ trades - successfully fetches all trades without 401 errors
- [x] Existing test suite passes (102 tests)
- [x] Linter (black) passes

## Is this a breaking change?

- [ ] Yes
- [x] No

## Type

- [x] Bug (correction to existing behavior)
- [ ] Feature (brand new functionality)
- [ ] Maintenance (documentation, tests, dependencies, etc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Regenerates Level 2/builder auth headers inside pagination loops for `get_orders`, `get_trades`, and `get_builder_trades` to prevent signature expiry.
> 
> - **Client (pagination auth)**:
>   - `get_orders`, `get_trades`: move `create_level_2_headers` inside the `while` loop to refresh HMAC per page.
>   - `get_builder_trades`: regenerate builder headers each iteration via `_get_builder_headers`.
>   - Adds brief comments explaining header regeneration to avoid signature expiry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b26a8ff7aeff8cc3dc033067facd0f1f0b00fab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->