### PR TITLE
Fix: deterministic json in rfq flows

### DIFF
--- a/py_clob_client/rfq/rfq_client.py
+++ b/py_clob_client/rfq/rfq_client.py
@@ -432,7 +432,7 @@ class RfqClient:
         body = {"quoteId": params.quote_id}
         serialized_body = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
         headers = self._get_l2_headers("DELETE", CANCEL_RFQ_QUOTE, body, serialized_body)
-        return delete(self._build_url(CANCEL_RFQ_QUOTE), headers=headers, data=body, serialized_body=serialized_body)
+        return delete(self._build_url(CANCEL_RFQ_QUOTE), headers=headers, data=serialized_body)
 
     # =========================================================================
     # Trade execution methods


### PR DESCRIPTION
<!-- Delete any sub-sections not used rather than leaving them empty. -->

## Overview

<!-- Provide a brief (1-3 sentence) summary of the PR and it's purpose. May include plans if a [WIP]. -->

## Description

<!-- Describe in detail what changes you plan to make in this section and sub-sections. -->

## Testing instructions

<!-- If the PR changes how tests should be run, describe here. -->

## Types of changes

<!-- Check one of the boxes below, and add additional information as necessary. -->

- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [ ] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

## Notes

<!-- Include any additional comments, links, questions, or discussion items here. -->

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation/changelog as needed.
- [ ] Verify all tests run correctly in CI and pass.
- [ ] Ready for review/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make RFQ requests/quotes use compact, deterministic JSON for L2 signing and HTTP payloads.
> 
> - **RFQ client (`py_clob_client/rfq/rfq_client.py`)**:
>   - Add `serialized_body` support to `_get_l2_headers`, propagating it to `RequestArgs.serialized_body` for signature generation.
>   - Serialize bodies with `json.dumps(..., separators=(",", ":"), ensure_ascii=False)` and send the serialized string as `data` for:
>     - `create_rfq_request`, `cancel_rfq_request`
>     - `create_rfq_quote`, `cancel_rfq_quote`
>     - `accept_rfq_quote`, `approve_rfq_order`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0641b52547383c1f599dcfea90b4f3159ea41854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->