### PR TITLE
Update checkout action version in workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Update `actions/checkout` to v6.0.1 for latest security patches and performance improvements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions workflow to use actions/checkout@v6.0.1.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68b8a1769a82c70d781d3447e1282600e0dd9509. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->