### PR TITLE
fix: rfq params cleanup

### DIFF
--- a/py_clob_client/rfq/rfq_helpers.py
+++ b/py_clob_client/rfq/rfq_helpers.py
@@ -85,7 +85,6 @@ def parse_rfq_requests_params(params: Optional[GetRfqRequestsParams] = None) -> 
 
     # Single value fields (convert snake_case to camelCase)
     single_fields = [
-        ("user_address", "userAddress"),
         ("state", "state"),
         ("size_min", "sizeMin"),
         ("size_max", "sizeMax"),
@@ -107,8 +106,6 @@ def parse_rfq_requests_params(params: Optional[GetRfqRequestsParams] = None) -> 
     # Array fields (keep as lists; let urlencode(doseq=True) expand them)
     if params.request_ids:
         result["requestIds"] = params.request_ids
-    if params.states:
-        result["states"] = params.states
     if params.markets:
         result["markets"] = params.markets
 
@@ -135,7 +132,6 @@ def parse_rfq_quotes_params(params: Optional[GetRfqQuotesParams] = None) -> Dict
 
     # Single value fields (convert snake_case to camelCase)
     single_fields = [
-        ("user_address", "userAddress"),
         ("state", "state"),
         ("size_min", "sizeMin"),
         ("size_max", "sizeMax"),
@@ -159,8 +155,6 @@ def parse_rfq_quotes_params(params: Optional[GetRfqQuotesParams] = None) -> Dict
         result["quoteIds"] = params.quote_ids
     if params.request_ids:
         result["requestIds"] = params.request_ids
-    if params.states:
-        result["states"] = params.states
     if params.markets:
         result["markets"] = params.markets
 

--- a/py_clob_client/rfq/rfq_types.py
+++ b/py_clob_client/rfq/rfq_types.py
@@ -5,7 +5,7 @@ This module defines all input and response types used by the RFQ client.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Literal
 from enum import Enum
 
 
@@ -176,19 +176,13 @@ class GetRfqRequestsParams:
     """
 
     request_ids: Optional[List[str]] = None
-    """Filter by specific request IDs."""
+    """Filter by specific request IDs (query param: requestIds; repeatable)."""
 
-    user_address: Optional[str] = None
-    """Filter by user address."""
-
-    states: Optional[List[str]] = None
-    """Filter by multiple states."""
-
-    state: Optional[str] = None
+    state: Optional[Literal["active", "inactive"]] = None
     """Single state filter ("active" or "inactive")."""
 
     markets: Optional[List[str]] = None
-    """Filter by market condition IDs."""
+    """Filter by market condition IDs (query param: markets; repeatable)."""
 
     size_min: Optional[float] = None
     """Minimum size filter."""
@@ -208,10 +202,10 @@ class GetRfqRequestsParams:
     price_max: Optional[float] = None
     """Maximum price filter."""
 
-    sort_by: Optional[str] = None
+    sort_by: Optional[Literal["price", "expiry", "size", "created"]] = None
     """Field to sort by."""
 
-    sort_dir: Optional[str] = None
+    sort_dir: Optional[Literal["asc", "desc"]] = None
     """Sort direction: "asc" or "desc"."""
 
     limit: Optional[int] = None
@@ -230,22 +224,16 @@ class GetRfqQuotesParams:
     """
 
     quote_ids: Optional[List[str]] = None
-    """Filter by specific quote IDs."""
+    """Filter by specific quote IDs (query param: quoteIds; repeatable)."""
 
     request_ids: Optional[List[str]] = None
-    """Filter by request IDs."""
+    """Filter by request IDs (query param: requestIds; repeatable)."""
 
-    user_address: Optional[str] = None
-    """Filter by user address."""
-
-    states: Optional[List[str]] = None
-    """Filter by multiple states."""
-
-    state: Optional[str] = None
-    """Single state filter."""
+    state: Optional[Literal["active", "inactive"]] = None
+    """Single state filter ("active" or "inactive")."""
 
     markets: Optional[List[str]] = None
-    """Filter by market condition IDs."""
+    """Filter by market condition IDs (query param: markets; repeatable)."""
 
     size_min: Optional[float] = None
     """Minimum size filter."""
@@ -265,10 +253,10 @@ class GetRfqQuotesParams:
     price_max: Optional[float] = None
     """Maximum price filter."""
 
-    sort_by: Optional[str] = None
+    sort_by: Optional[Literal["price", "expiry", "created"]] = None
     """Field to sort by."""
 
-    sort_dir: Optional[str] = None
+    sort_dir: Optional[Literal["asc", "desc"]] = None
     """Sort direction: "asc" or "desc"."""
 
     limit: Optional[int] = None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="py_clob_client",
-    version="0.34.4",
+    version="0.34.5",
     author="Polymarket Engineering",
     author_email="engineering@polymarket.com",
     maintainer="Polymarket Engineering",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines RFQ query parameters and their parsing for requests and quotes.
> 
> - Tightens types in `GetRfqRequestsParams` and `GetRfqQuotesParams`: remove `user_address` and `states`, restrict `state` to "active"/"inactive", constrain `sort_by`/`sort_dir` via `Literal`, and document repeatable arrays (`requestIds`, `quoteIds`, `markets`).
> - Updates `parse_rfq_requests_params` and `parse_rfq_quotes_params` to stop emitting removed fields and only include supported arrays; maintains snake-to-camel mapping for single fields.
> - Bumps package version to `0.34.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9140df80a6c2cb23ef3e89e2149e1f79d72a73e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->