### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(),
-    include_package_data=True,
     package_data={"py_clob_client": ["py.typed"]},
     python_requires=">=3.9.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(),
+    include_package_data=True,
+    package_data={"py_clob_client": ["py.typed"]},
     python_requires=">=3.9.10",
 )


### PR DESCRIPTION
Added py.typed marker file to the package directory to indicate that a package supports static type checking. 
Without py.typed: Type checkers treat your library as `Any`, so users won't get type validation for your functions.

UPD Well, adding py.typed is not enough. Actually PR should add type checker and fix all errors found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change that marks the library as typed; no runtime logic changes and minimal risk beyond distribution/config correctness.
> 
> **Overview**
> Marks `py_clob_client` as a typed package by adding the `py.typed` marker and ensuring it is included in the published distribution via `package_data` in `setup.py`, enabling static type checkers to use the library’s type hints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8633150e3b6842973c0752d23e70e5d6762a33c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->