### PR TITLE
fix: tick size cache

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -435,7 +435,7 @@ class ClobClient:
         Opportunistically updates the tick size cache from an order book response.
         """
         if book and book.asset_id and book.tick_size:
-            self.__tick_sizes[book.asset_id] = book.tick_size
+            self.__tick_sizes[book.asset_id] = str(book.tick_size)
             self.__tick_size_timestamps[book.asset_id] = time.monotonic()
 
     def get_neg_risk(self, token_id: str) -> bool:

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import time
 from typing import Optional
 
 from py_builder_signing_sdk.config import BuilderConfig
@@ -122,6 +123,7 @@ class ClobClient:
         signature_type: int = None,
         funder: str = None,
         builder_config: BuilderConfig = None,
+        tick_size_ttl: float = 300.0,
     ):
         """
         Initializes the clob client
@@ -152,6 +154,8 @@ class ClobClient:
 
         # local cache
         self.__tick_sizes = {}
+        self.__tick_size_timestamps = {}
+        self.__tick_size_ttl = tick_size_ttl
         self.__neg_risk = {}
         self.__fee_rates = {}
 
@@ -396,13 +400,43 @@ class ClobClient:
         return post("{}{}".format(self.host, GET_SPREADS), data=body)
 
     def get_tick_size(self, token_id: str) -> TickSize:
-        if token_id in self.__tick_sizes:
+        cached_at = self.__tick_size_timestamps.get(token_id)
+
+        if (
+            token_id in self.__tick_sizes
+            and cached_at is not None
+            and (time.monotonic() - cached_at) < self.__tick_size_ttl
+        ):
             return self.__tick_sizes[token_id]
 
         result = get("{}{}?token_id={}".format(self.host, GET_TICK_SIZE, token_id))
         self.__tick_sizes[token_id] = str(result["minimum_tick_size"])
+        self.__tick_size_timestamps[token_id] = time.monotonic()
 
         return self.__tick_sizes[token_id]
+
+    def clear_tick_size_cache(self, token_id: str = None):
+        """
+        Clears the tick size cache, forcing fresh fetches on the next access.
+
+        Args:
+            token_id: If provided, only clears the cache for this token.
+                      Otherwise clears all cached tick sizes.
+        """
+        if token_id is not None:
+            self.__tick_sizes.pop(token_id, None)
+            self.__tick_size_timestamps.pop(token_id, None)
+        else:
+            self.__tick_sizes.clear()
+            self.__tick_size_timestamps.clear()
+
+    def _update_tick_size_from_order_book(self, book: OrderBookSummary):
+        """
+        Opportunistically updates the tick size cache from an order book response.
+        """
+        if book and book.asset_id and book.tick_size:
+            self.__tick_sizes[book.asset_id] = book.tick_size
+            self.__tick_size_timestamps[book.asset_id] = time.monotonic()
 
     def get_neg_risk(self, token_id: str) -> bool:
         if token_id in self.__neg_risk:
@@ -739,7 +773,9 @@ class ClobClient:
         Fetches the orderbook for the token_id
         """
         raw_obs = get("{}{}?token_id={}".format(self.host, GET_ORDER_BOOK, token_id))
-        return parse_raw_orderbook_summary(raw_obs)
+        result = parse_raw_orderbook_summary(raw_obs)
+        self._update_tick_size_from_order_book(result)
+        return result
 
     def get_order_books(self, params: list[BookParams]) -> list[OrderBookSummary]:
         """
@@ -747,7 +783,10 @@ class ClobClient:
         """
         body = [{"token_id": param.token_id} for param in params]
         raw_obs = post("{}{}".format(self.host, GET_ORDER_BOOKS), data=body)
-        return [parse_raw_orderbook_summary(r) for r in raw_obs]
+        results = [parse_raw_orderbook_summary(r) for r in raw_obs]
+        for book in results:
+            self._update_tick_size_from_order_book(book)
+        return results
 
     def get_order_book_hash(self, orderbook: OrderBookSummary) -> str:
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="py_clob_client",
-    version="0.34.5",
+    version="0.34.6",
     author="Polymarket Engineering",
     author_email="engineering@polymarket.com",
     maintainer="Polymarket Engineering",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Limited to client-side caching behavior for tick sizes and a version bump; low risk aside from potentially changing when tick sizes are refetched.
> 
> **Overview**
> Improves tick-size caching in `ClobClient` by adding **TTL-based invalidation** (default 300s), storing monotonic timestamps per token, and exposing `clear_tick_size_cache()` to force refreshes.
> 
> `get_order_book()`/`get_order_books()` now **opportunistically update** the tick-size cache from `OrderBookSummary.tick_size` responses to reduce extra tick-size fetches. Package version is bumped to `0.34.6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d5d7806b4b35e961a4e50a7a2ac0018113465c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->