### PR TITLE
fix: floating point precision in rounding helpers (#253)

### DIFF
--- a/py_clob_client/order_builder/helpers.py
+++ b/py_clob_client/order_builder/helpers.py
@@ -3,14 +3,20 @@ from decimal import Decimal
 
 
 def round_down(x: float, sig_digits: int) -> float:
+    if decimal_places(x) <= sig_digits:
+        return x
     return floor(x * (10**sig_digits)) / (10**sig_digits)
 
 
 def round_normal(x: float, sig_digits: int) -> float:
+    if decimal_places(x) <= sig_digits:
+        return x
     return round(x * (10**sig_digits)) / (10**sig_digits)
 
 
 def round_up(x: float, sig_digits: int) -> float:
+    if decimal_places(x) <= sig_digits:
+        return x
     return ceil(x * (10**sig_digits)) / (10**sig_digits)
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to numeric rounding behavior; risk is limited to slight behavioral differences at precision boundaries in order amount calculations.
> 
> **Overview**
> Improves rounding helpers used by the order builder to reduce floating-point precision artifacts.
> 
> `round_down`, `round_normal`, and `round_up` now short-circuit and return the original value when it already has `<= sig_digits` decimal places, avoiding additional multiply/divide operations that can introduce tiny rounding errors (impacting order amount calculations via `to_token_decimals`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6534fb89761075470a4f5f3054b949e2acd4b98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->