### PR TITLE
fix: add builder auth support to get_order and get_orders

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -755,6 +755,11 @@ class ClobClient:
         self.assert_level_2_auth()
         request_args = RequestArgs(method="GET", request_path=ORDERS)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
+        # Builder flow
+        if self.can_builder_auth():
+            builder_headers = self._generate_builder_headers(request_args, headers)
+            if builder_headers is not None:
+                headers = builder_headers
 
         results = []
         next_cursor = next_cursor if next_cursor is not None else "MA=="
@@ -803,6 +808,11 @@ class ClobClient:
         endpoint = "{}{}".format(GET_ORDER, order_id)
         request_args = RequestArgs(method="GET", request_path=endpoint)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
+        # Builder flow
+        if self.can_builder_auth():
+            builder_headers = self._generate_builder_headers(request_args, headers)
+            if builder_headers is not None:
+                return get("{}{}".format(self.host, endpoint), headers=builder_headers)
         return get("{}{}".format(self.host, endpoint), headers=headers)
 
     def get_trades(self, params: TradeParams = None, next_cursor="MA=="):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects request headers for two GET endpoints and falls back to existing behavior if builder header generation fails.
> 
> **Overview**
> Adds optional *builder authentication* handling to `ClobClient.get_orders` and `ClobClient.get_order` by attempting to generate builder headers and using them when available.
> 
> This brings these read endpoints in line with existing builder-header usage on order-posting calls, while preserving the existing Level 2 header flow as a fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad19165ae7e9c98d33842a714fa78bfa03c13ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->