### PR TITLE
Update README to reflect USDC.e instead of USDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ print(last, len(trades))
 - **Using MetaMask or hardware wallet?** You need to set allowances before trading.
 
 ### What are allowances?
-Think of allowances as permissions. Before Polymarket can move your funds to execute trades, you need to give the exchange contracts permission to access your USDC and conditional tokens.
+Think of allowances as permissions. Before Polymarket can move your funds to execute trades, you need to give the exchange contracts permission to access your USDC.e and conditional tokens.
 
 ### Quick Setup
 You need to approve two types of tokens:
-1. **USDC** (for deposits and trading)
+1. **USDC.e** (for deposits and trading)
 2. **Conditional Tokens** (the outcome tokens you trade)
 
 Each needs approval for the exchange contracts to work properly.
@@ -250,7 +250,7 @@ Each needs approval for the exchange contracts to work properly.
 ### Setting Allowances
 Here's a simple breakdown of what needs to be approved:
 
-**For USDC (your trading currency):**
+**For USDC.e (your trading currency):**
 - Token: `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`
 - Approve for these contracts:
   - `0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E` (Main exchange)


### PR DESCRIPTION
Corrected references from USDC to USDC.e in the allowances section.

## Overview

This fixes an error in the documentation about which token needs to be approved.

## Testing instructions

Read the diff.

## Types of changes

- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [x] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

## Notes

<!-- Include any additional comments, links, questions, or discussion items here. -->

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [ ] Add tests to cover changes as needed.
- [x] Update documentation/changelog as needed.
- [x] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no code or runtime behavior is affected.
> 
> **Overview**
> Updates the README’s MetaMask/EOA token allowance instructions to consistently reference **`USDC.e`** (instead of `USDC`) as the token users must approve for deposits/trading.
> 
> Also fixes a missing trailing newline at the end of `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dd3b5bfbcc7cd285dded2897371f167e2c64ecb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->