### PR TITLE
fix: tick size cache stale — force refresh on order create, better er…

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,26 @@ See [this Python example](https://gist.github.com/poly-rodr/44313920481de58d5a3f
 
 **Pro tip**: You only need to set these once per wallet. After that, you can trade freely.
 
+## Tick size and order rejection
+
+The client **caches** each market’s minimum tick size (from `get_tick_size`) for a short time to reduce API calls. When you **create or sign orders** (`create_order`, `create_market_order`), the client always fetches the **current** tick size from the CLOB, so signed orders use the correct value even if the cache is stale.
+
+- **Using `get_tick_size` elsewhere** (e.g. for display or validation): if the market’s tick size may have changed on the CLOB, either call `get_tick_size(token_id, force_refresh=True)` or clear the cache first: `client.clear_tick_size_cache(token_id)` (or `client.clear_tick_size_cache()` for all tokens).
+- **Order rejected by the API**: if the server rejects an order and the error is related to tick size or price precision, the client may raise `TickSizeRejectedError` with a message suggesting you clear the tick size cache and retry:
+  ```python
+  from py_clob_client import ClobClient, TickSizeRejectedError
+
+  try:
+      resp = client.post_order(signed, OrderType.GTC)
+  except TickSizeRejectedError as e:
+      # Market tick size may have changed; clear cache and retry
+      client.clear_tick_size_cache()  # or client.clear_tick_size_cache(token_id)
+      # Re-create and post the order
+  ```
+
 ## Notes
 - To discover token IDs, use the Markets API Explorer: [Get Markets](https://docs.polymarket.com/developers/gamma-markets-api/get-markets).
 - Prices are in dollars from 0.00 to 1.00. Shares are whole or fractional units of the outcome token.
+- If an order is rejected due to tick size or price precision, see [Tick size and order rejection](#tick-size-and-order-rejection) above.
 
 See [/example](/examples) for more.

--- a/py_clob_client/__init__.py
+++ b/py_clob_client/__init__.py
@@ -1,4 +1,5 @@
 from .client import ClobClient
+from .exceptions import TickSizeRejectedError
 from .clob_types import (
     ApiCreds,
     OrderArgs,
@@ -38,6 +39,8 @@ from .rfq import (
 __all__ = [
     # Main client
     "ClobClient",
+    # Exceptions
+    "TickSizeRejectedError",
     # Core types
     "ApiCreds",
     "OrderArgs",

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -82,7 +82,7 @@ from .clob_types import (
     MarketOrderArgs,
     PostOrdersArgs,
 )
-from .exceptions import PolyException
+from .exceptions import PolyException, PolyApiException, TickSizeRejectedError
 from .http_helpers.helpers import (
     add_query_trade_params,
     add_query_open_orders_params,
@@ -399,11 +399,22 @@ class ClobClient:
         body = [{"token_id": param.token_id} for param in params]
         return post("{}{}".format(self.host, GET_SPREADS), data=body)
 
-    def get_tick_size(self, token_id: str) -> TickSize:
+    def get_tick_size(self, token_id: str, force_refresh: bool = False) -> TickSize:
+        """
+        Returns the minimum tick size for the given token (market).
+
+        Results are cached for tick_size_ttl seconds. If the order book's tick
+        size has changed on the CLOB, you may get a stale value until the cache
+        expires or you force a refresh. When signing orders, the client
+        automatically uses a fresh tick size; if you use get_tick_size elsewhere
+        and the market may have changed, pass force_refresh=True or call
+        clear_tick_size_cache(token_id) first.
+        """
         cached_at = self.__tick_size_timestamps.get(token_id)
 
         if (
-            token_id in self.__tick_sizes
+            not force_refresh
+            and token_id in self.__tick_sizes
             and cached_at is not None
             and (time.monotonic() - cached_at) < self.__tick_size_ttl
         ):
@@ -438,6 +449,14 @@ class ClobClient:
             self.__tick_sizes[book.asset_id] = str(book.tick_size)
             self.__tick_size_timestamps[book.asset_id] = time.monotonic()
 
+    @staticmethod
+    def _is_tick_size_related_error(error_msg) -> bool:
+        """True if the API error message is likely due to tick size / price precision."""
+        if error_msg is None:
+            return False
+        s = json.dumps(error_msg).lower() if isinstance(error_msg, dict) else str(error_msg).lower()
+        return "tick" in s or "precision" in s or "minimum_tick" in s
+
     def get_neg_risk(self, token_id: str) -> bool:
         if token_id in self.__neg_risk:
             return self.__neg_risk[token_id]
@@ -458,9 +477,12 @@ class ClobClient:
         return fee_rate
 
     def __resolve_tick_size(
-        self, token_id: str, tick_size: TickSize = None
+        self,
+        token_id: str,
+        tick_size: TickSize = None,
+        force_refresh: bool = False,
     ) -> TickSize:
-        min_tick_size = self.get_tick_size(token_id)
+        min_tick_size = self.get_tick_size(token_id, force_refresh=force_refresh)
         if tick_size is not None:
             if is_tick_size_smaller(tick_size, min_tick_size):
                 raise Exception(
@@ -498,10 +520,11 @@ class ClobClient:
         """
         self.assert_level_1_auth()
 
-        # add resolve_order_options, or similar
+        # Resolve tick size from CLOB (force refresh to avoid stale cache when signing)
         tick_size = self.__resolve_tick_size(
             order_args.token_id,
             options.tick_size if options else None,
+            force_refresh=True,
         )
 
         if not price_valid(order_args.price, tick_size):
@@ -545,10 +568,11 @@ class ClobClient:
         """
         self.assert_level_1_auth()
 
-        # add resolve_order_options, or similar
+        # Resolve tick size from CLOB (force refresh to avoid stale cache when signing)
         tick_size = self.__resolve_tick_size(
             order_args.token_id,
             options.tick_size if options else None,
+            force_refresh=True,
         )
 
         if order_args.price is None or order_args.price <= 0:
@@ -604,21 +628,28 @@ class ClobClient:
             serialized_body=json.dumps(body, separators=(",", ":"), ensure_ascii=False),
         )
         headers = create_level_2_headers(self.signer, self.creds, request_args)
-        # Builder flow
-        if self.can_builder_auth():
-            builder_headers = self._generate_builder_headers(request_args, headers)
-            if builder_headers is not None:
-                return post(
-                    "{}{}".format(self.host, POST_ORDERS),
-                    headers=builder_headers,
-                    data=request_args.serialized_body,
-                )
-        # send exact serialized bytes
-        return post(
-            "{}{}".format(self.host, POST_ORDERS),
-            headers=headers,
-            data=request_args.serialized_body,
-        )
+        try:
+            # Builder flow
+            if self.can_builder_auth():
+                builder_headers = self._generate_builder_headers(request_args, headers)
+                if builder_headers is not None:
+                    return post(
+                        "{}{}".format(self.host, POST_ORDERS),
+                        headers=builder_headers,
+                        data=request_args.serialized_body,
+                    )
+            # send exact serialized bytes
+            return post(
+                "{}{}".format(self.host, POST_ORDERS),
+                headers=headers,
+                data=request_args.serialized_body,
+            )
+        except PolyApiException as e:
+            if self._is_tick_size_related_error(e.error_msg):
+                err = TickSizeRejectedError(str(e.error_msg), api_exception=e)
+                err.__cause__ = e
+                raise err
+            raise
 
     def post_order(self, order, orderType: OrderType = OrderType.GTC, post_only: bool = False):
         """
@@ -636,20 +667,27 @@ class ClobClient:
             serialized_body=json.dumps(body, separators=(",", ":"), ensure_ascii=False),
         )
         headers = create_level_2_headers(self.signer, self.creds, request_args)
-        # Builder flow
-        if self.can_builder_auth():
-            builder_headers = self._generate_builder_headers(request_args, headers)
-            if builder_headers is not None:
-                return post(
-                    "{}{}".format(self.host, POST_ORDER),
-                    headers=builder_headers,
-                    data=request_args.serialized_body,
-                )
-        return post(
-            "{}{}".format(self.host, POST_ORDER),
-            headers=headers,
-            data=request_args.serialized_body,
-        )
+        try:
+            # Builder flow
+            if self.can_builder_auth():
+                builder_headers = self._generate_builder_headers(request_args, headers)
+                if builder_headers is not None:
+                    return post(
+                        "{}{}".format(self.host, POST_ORDER),
+                        headers=builder_headers,
+                        data=request_args.serialized_body,
+                    )
+            return post(
+                "{}{}".format(self.host, POST_ORDER),
+                headers=headers,
+                data=request_args.serialized_body,
+            )
+        except PolyApiException as e:
+            if self._is_tick_size_related_error(e.error_msg):
+                err = TickSizeRejectedError(str(e.error_msg), api_exception=e)
+                err.__cause__ = e
+                raise err
+            raise
 
     def create_and_post_order(
         self, order_args: OrderArgs, options: PartialCreateOrderOptions = None

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -454,10 +454,32 @@ class ClobClient:
         """True if the API error message is likely due to tick size / price precision."""
         if error_msg is None:
             return False
-        msg = str(error_msg).lower()
+        msg = ClobClient._error_message_to_string(error_msg)
         return any(
             kw in msg for kw in ("tick", "precision", "minimum_tick")
         )
+
+    @staticmethod
+    def _flatten_error_message(value) -> str:
+        """Flatten dict/list error payloads into a single string (preserves casing)."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            return " ".join(
+                ClobClient._flatten_error_message(v) for v in value.values()
+            )
+        if isinstance(value, (list, tuple)):
+            return " ".join(
+                ClobClient._flatten_error_message(v) for v in value
+            )
+        return str(value)
+
+    @staticmethod
+    def _error_message_to_string(value) -> str:
+        """Flatten dict/list error payloads into a single lowercase string for keyword search."""
+        return ClobClient._flatten_error_message(value).lower()
 
     def get_neg_risk(self, token_id: str) -> bool:
         if token_id in self.__neg_risk:
@@ -648,7 +670,9 @@ class ClobClient:
             )
         except PolyApiException as e:
             if self._is_tick_size_related_error(e.error_msg):
-                err = TickSizeRejectedError(str(e.error_msg), api_exception=e)
+                err = TickSizeRejectedError(
+                    self._flatten_error_message(e.error_msg), api_exception=e
+                )
                 err.__cause__ = e
                 raise err
             raise
@@ -686,7 +710,9 @@ class ClobClient:
             )
         except PolyApiException as e:
             if self._is_tick_size_related_error(e.error_msg):
-                err = TickSizeRejectedError(str(e.error_msg), api_exception=e)
+                err = TickSizeRejectedError(
+                    self._flatten_error_message(e.error_msg), api_exception=e
+                )
                 err.__cause__ = e
                 raise err
             raise

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -454,8 +454,6 @@ class ClobClient:
         """True if the API error message is likely due to tick size / price precision."""
         if error_msg is None:
             return False
-        s = json.dumps(error_msg).lower() if isinstance(error_msg, dict) else str(error_msg).lower()
-        return "tick" in s or "precision" in s or "minimum_tick" in s
 
     def get_neg_risk(self, token_id: str) -> bool:
         if token_id in self.__neg_risk:

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -454,6 +454,10 @@ class ClobClient:
         """True if the API error message is likely due to tick size / price precision."""
         if error_msg is None:
             return False
+        msg = str(error_msg).lower()
+        return any(
+            kw in msg for kw in ("tick", "precision", "minimum_tick")
+        )
 
     def get_neg_risk(self, token_id: str) -> bool:
         if token_id in self.__neg_risk:

--- a/py_clob_client/exceptions.py
+++ b/py_clob_client/exceptions.py
@@ -30,3 +30,27 @@ class PolyApiException(PolyException):
 
     def __str__(self):
         return self.__repr__()
+
+
+class TickSizeRejectedError(PolyException):
+    """
+    Raised when an order is rejected and the error is likely due to tick size /
+    price precision (e.g. the market's tick size changed on the CLOB). Clear the
+    tick size cache and retry: client.clear_tick_size_cache() or
+    client.clear_tick_size_cache(token_id), then create and post the order again.
+    """
+
+    def __init__(self, msg, api_exception=None):
+        self.api_exception = api_exception
+        hint = (
+            "Clear tick size cache: client.clear_tick_size_cache() or "
+            "client.clear_tick_size_cache(token_id), then create and post the order again."
+        )
+        self.msg = f"{msg}. {hint}"
+        super().__init__(self.msg)
+
+    def __str__(self):
+        return self.msg
+
+    def __repr__(self):
+        return f"TickSizeRejectedError({self.msg!r})"

--- a/py_clob_client/exceptions.py
+++ b/py_clob_client/exceptions.py
@@ -32,7 +32,7 @@ class PolyApiException(PolyException):
         return self.__repr__()
 
 
-class TickSizeRejectedError(PolyException):
+class TickSizeRejectedError(PolyApiException):
     """
     Raised when an order is rejected and the error is likely due to tick size /
     price precision (e.g. the market's tick size changed on the CLOB). Clear the
@@ -47,7 +47,9 @@ class TickSizeRejectedError(PolyException):
             "client.clear_tick_size_cache(token_id), then create and post the order again."
         )
         self.msg = f"{msg}. {hint}"
-        super().__init__(self.msg)
+        super().__init__(error_msg=self.msg)
+        if api_exception is not None:
+            self.status_code = api_exception.status_code
 
     def __str__(self):
         return self.msg

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,55 @@
+"""Tests for ClobClient error message handling (tick size detection)."""
+from unittest import TestCase
+
+from py_clob_client.client import ClobClient
+
+
+class TestClientTickSizeErrorDetection(TestCase):
+    """Test _is_tick_size_related_error and _flatten_error_message with dict/string payloads."""
+
+    def test_is_tick_size_related_error_string_plain(self):
+        self.assertTrue(ClobClient._is_tick_size_related_error("invalid tick size"))
+        self.assertTrue(ClobClient._is_tick_size_related_error("Price precision error"))
+        self.assertTrue(ClobClient._is_tick_size_related_error("minimum_tick violated"))
+        self.assertFalse(ClobClient._is_tick_size_related_error("insufficient balance"))
+        self.assertFalse(ClobClient._is_tick_size_related_error(""))
+
+    def test_is_tick_size_related_error_string_none(self):
+        self.assertFalse(ClobClient._is_tick_size_related_error(None))
+
+    def test_is_tick_size_related_error_dict_nested_message(self):
+        # API returns resp.json() e.g. {"error": {"message": "invalid tick size"}}
+        payload = {"error": {"message": "invalid tick size"}}
+        self.assertTrue(ClobClient._is_tick_size_related_error(payload))
+
+    def test_is_tick_size_related_error_dict_precision_deep(self):
+        payload = {"detail": {"reason": "Price precision does not match"}}
+        self.assertTrue(ClobClient._is_tick_size_related_error(payload))
+
+    def test_is_tick_size_related_error_dict_minimum_tick(self):
+        payload = {"message": "Order violates minimum_tick"}
+        self.assertTrue(ClobClient._is_tick_size_related_error(payload))
+
+    def test_is_tick_size_related_error_dict_unrelated(self):
+        payload = {"error": {"message": "insufficient balance"}}
+        self.assertFalse(ClobClient._is_tick_size_related_error(payload))
+
+    def test_flatten_error_message_string(self):
+        self.assertEqual(ClobClient._flatten_error_message("hello"), "hello")
+
+    def test_flatten_error_message_dict_nested(self):
+        payload = {"error": {"message": "invalid tick size"}}
+        self.assertEqual(
+            ClobClient._flatten_error_message(payload), "invalid tick size"
+        )
+
+    def test_flatten_error_message_dict_multiple_keys(self):
+        payload = {"msg": "precision", "code": 400}
+        self.assertIn("precision", ClobClient._flatten_error_message(payload))
+
+    def test_flatten_error_message_list(self):
+        payload = ["first", "minimum_tick error"]
+        self.assertIn("minimum_tick", ClobClient._flatten_error_message(payload))
+
+    def test_flatten_error_message_none(self):
+        self.assertEqual(ClobClient._flatten_error_message(None), "")


### PR DESCRIPTION
fix: tick size cache — force refresh on order create, clearer error on reject

<!-- Delete any sub-sections not used rather than leaving them empty. -->

## Overview

This PR fixes the case where orders are rejected by the CLOB because the client used a **stale tick size** from its cache after the order book’s tick size changed on the server. It does two things: (1) always fetches the current tick size from the CLOB when creating/signing orders, and (2) raises a dedicated `TickSizeRejectedError` with a clear message when the API rejects an order due to tick size or price precision, so users know to clear the cache and retry.

## Description

**Problem:** The client caches each market’s minimum tick size (from `get_tick_size`) for a TTL. If the CLOB updates a market’s tick size, the cache can still hold the old value. Users who rely on `get_tick_size` (or who signed orders earlier) may then submit orders with an outdated tick size and get rejected by the API, with no indication that the failure is due to cache vs. CLOB.

**Changes:**

- **Force refresh when creating orders:** `create_order` and `create_market_order` now call `__resolve_tick_size(..., force_refresh=True)`, so the tick size used for signing is always fetched from the CLOB and never taken from cache. This prevents rejections caused by stale tick size on the create/sign path.

- **`get_tick_size(token_id, force_refresh=False)`:** A new optional argument `force_refresh` skips the cache and fetches from the API, then updates the cache. Docstring updated to explain that when the market’s tick size may have changed, callers should use `force_refresh=True` or call `clear_tick_size_cache(token_id)` first.

- **`TickSizeRejectedError`:** When `post_order` or `post_orders` receives an API error whose message suggests tick size or price precision (e.g. contains "tick", "precision", "minimum_tick"), the client raises `TickSizeRejectedError` instead of a generic `PolyApiException`. The message tells the user to clear the tick size cache and retry. The original API exception is preserved as `__cause__`.

- **Package export:** `TickSizeRejectedError` is exported from `py_clob_client` so callers can catch it and implement retry or user-facing messaging.

- **Documentation:** README now has a “Tick size and order rejection” section describing cache behavior, when to use `force_refresh` / `clear_tick_size_cache`, and how to handle `TickSizeRejectedError`. Notes section references this for order-rejection issues.

## Testing instructions

- Run the test suite: `pytest tests/ -v`. If the environment hits the `eth_typing` / `ContractName` import error when loading pytest plugins, fix the environment (e.g. `pip install 'eth_typing<4.2.0'` or `pip install -U web3`) then re-run.
- Manually: after a market’s tick size changes on the CLOB, confirm that new orders created via `create_order` / `create_market_order` still succeed (tick size is refreshed). When the API rejects an order with a tick-size-related error, confirm that `TickSizeRejectedError` is raised and the message suggests clearing the cache and retrying.

## Types of changes

- [x] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] Refactor/enhancement
- [ ] New feature
- [ ] Breaking change
- [ ] Other, additional

## Notes

- Default behavior of `get_tick_size` is unchanged (still uses cache). Only the order-creation path forces a refresh.
- Other code paths (e.g. RFQ) that use `__resolve_tick_size` still use the cache unless they are updated to pass `force_refresh=True` where appropriate.
- Detection of “tick-size-related” errors is heuristic (message contains "tick", "precision", or "minimum_tick"). If the CLOB uses different wording, those rejections will still be raised as `PolyApiException`.

## Status

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [ ] Add tests to cover changes as needed.
- [x] Update documentation/changelog as needed.
- [ ] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order creation and error-handling behavior on the trading path, which could affect how clients retry/handle failed submissions; logic is small and covered by focused tests.
> 
> **Overview**
> Prevents stale tick-size cache from causing order rejections by forcing a fresh `get_tick_size(..., force_refresh=True)` when `create_order`/`create_market_order` resolve tick size for signing.
> 
> Adds `get_tick_size(token_id, force_refresh=False)` and introduces `TickSizeRejectedError`, raised from `post_order`/`post_orders` when a `PolyApiException` message looks tick/precision-related (with helpers to flatten/inspect structured error payloads); exports the exception from `py_clob_client`, documents cache/refresh guidance in `README.md`, and adds unit tests for the error detection/flattening logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b077da848398238c961e3588aedbb9de73a1c185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->