### PR TITLE
fix: use Decimal.quantize for base-10 rounding precision

### DIFF
--- a/py_clob_client/order_builder/helpers.py
+++ b/py_clob_client/order_builder/helpers.py
@@ -1,24 +1,24 @@
-from math import floor, ceil
-from decimal import Decimal
+from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_UP, ROUND_CEILING
 
 
 def round_down(x: float, sig_digits: int) -> float:
-    return floor(x * (10**sig_digits)) / (10**sig_digits)
+    d = Decimal(str(x))
+    return float(d.quantize(Decimal(10) ** -sig_digits, rounding=ROUND_FLOOR))
 
 
 def round_normal(x: float, sig_digits: int) -> float:
-    return round(x * (10**sig_digits)) / (10**sig_digits)
+    d = Decimal(str(x))
+    return float(d.quantize(Decimal(10) ** -sig_digits, rounding=ROUND_HALF_UP))
 
 
 def round_up(x: float, sig_digits: int) -> float:
-    return ceil(x * (10**sig_digits)) / (10**sig_digits)
+    d = Decimal(str(x))
+    return float(d.quantize(Decimal(10) ** -sig_digits, rounding=ROUND_CEILING))
 
 
 def to_token_decimals(x: float) -> int:
-    f = (10**6) * x
-    if decimal_places(f) > 0:
-        f = round_normal(f, 0)
-    return int(f)
+    d = Decimal(str(x)) * Decimal("1000000")
+    return int(d.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
 def decimal_places(x: float) -> int:

--- a/py_clob_client/order_builder/helpers.py
+++ b/py_clob_client/order_builder/helpers.py
@@ -1,4 +1,4 @@
-from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_UP, ROUND_CEILING
+from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_EVEN, ROUND_CEILING
 
 
 def round_down(x: float, sig_digits: int) -> float:
@@ -8,7 +8,7 @@ def round_down(x: float, sig_digits: int) -> float:
 
 def round_normal(x: float, sig_digits: int) -> float:
     d = Decimal(str(x))
-    return float(d.quantize(Decimal(10) ** -sig_digits, rounding=ROUND_HALF_UP))
+    return float(d.quantize(Decimal(10) ** -sig_digits, rounding=ROUND_HALF_EVEN))
 
 
 def round_up(x: float, sig_digits: int) -> float:
@@ -18,7 +18,7 @@ def round_up(x: float, sig_digits: int) -> float:
 
 def to_token_decimals(x: float) -> int:
     d = Decimal(str(x)) * Decimal("1000000")
-    return int(d.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    return int(d.quantize(Decimal("1"), rounding=ROUND_HALF_EVEN))
 
 
 def decimal_places(x: float) -> int:


### PR DESCRIPTION
round_down(9.53, 2) currently returns 9.52 because floor(9.53 * 100) hits 
IEEE 754 representation (952.999...) and floors to 952. Same issue in 
round_up, round_normal, and to_token_decimals.

This replaces float arithmetic with Decimal(str(x)).quantize() — the Decimal 
import was already there for decimal_places() but unused for rounding. No new 
deps, no signature changes, all 82 existing tests pass.

Closes #142

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rounding and amount conversion used to compute on-chain order amounts; small numeric behavior shifts could affect order sizing/price edge cases despite being a targeted fix for float precision issues.
> 
> **Overview**
> Fixes float precision edge cases in order amount/price rounding by replacing `floor/ceil/round`-based math with `Decimal(str(x)).quantize(...)` in `round_down`, `round_normal`, and `round_up`.
> 
> Simplifies `to_token_decimals` to convert to 6-decimal token units via `Decimal` multiplication and `ROUND_HALF_EVEN` quantization, removing the prior `decimal_places`/extra rounding step so order amount calculations are deterministic in base-10.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a323da82bd0b47a559cdf850ce4562e4993f2a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->