### PR TITLE
docs: clarify redemption/settlement scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ resp = client.post_order(signed, OrderType.GTC)
 print(resp)
 ```
 
+### Redeeming resolved positions (important)
+
+`py-clob-client` targets CLOB trading APIs (orders, books, trades, balances).
+
+At the moment, **redeeming/settling resolved market positions is not exposed as a direct SDK helper** in this package. If you need to redeem winnings from resolved markets, use the official Polymarket app/workflow or a dedicated settlement path from Polymarket docs/tools.
+
 ### Manage orders
 
 **Note**: EOA/MetaMask users must set token allowances before trading. See [Token Allowances section](#important-token-allowances-for-metamaskeoa-users) below.


### PR DESCRIPTION
Related to #295

## Summary
- Add a dedicated README section clarifying that `py-clob-client` currently focuses on CLOB trading APIs (orders/books/trades/balances).
- Explicitly notes that redeem/settlement of resolved positions is not exposed as a direct SDK helper in this package.
- Points users toward official Polymarket app/workflow or dedicated settlement tools/docs.

This should reduce confusion for users expecting redemption via this client package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that clarifies SDK scope and points users to external settlement workflows; no runtime behavior is affected.
> 
> **Overview**
> Adds a new README section, **"Redeeming resolved positions (important)"**, clarifying that `py-clob-client` currently covers only CLOB trading APIs and does *not* provide an SDK helper for redeeming/settling resolved positions, directing users to the official Polymarket app/workflow or other settlement docs/tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d0ece69ad0ef6286fc6546316006b4a08cb15f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->