### PR TITLE
docs: add order requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ signed = client.create_order(order)
 resp = client.post_order(signed, OrderType.GTC)
 print(resp)
 ```
+### Order requirements
+
+Before placing orders, note the following CLOB requirements:
+
+**Minimum order size**: 5 shares. Applies to both limit and market orders. Orders below this will be rejected with a `Size lower than the minimum: 5` error. 
+**Minimum tick size**: 0.01. Prices must be in increments of $0.01 (e.g., 0.50, 0.51). 
+**Price range**: 0.01 – 0.99. Prices outside this range are invalid. 
+
+**Common pitfall**: If you're placing a small dollar amount (e.g., $1.00) at a high price (e.g., $0.95), the resulting share count may fall below 5 — causing the order to be rejected. Make sure your `amount / price ≥ 5` for market orders, or `size ≥ 5` for limit orders.
 
 ### Manage orders
 


### PR DESCRIPTION
Overview
Adds an "Order requirements" section to the README documenting minimum order size, tick size, and valid price range. Addresses user confusion reported in #301.

Description
Added a new section between "Place a limit order" and "Manage orders" that documents:

Minimum order size (5 shares)
Minimum tick size (0.01)
Valid price range (0.01–0.99)
A common pitfall note explaining why small dollar amounts at high prices get rejected


Types of changes
Other, additional <!-- Documentation update only (README.md). -->

Notes
Fixes #301 - users placing small dollar orders are getting Size lower than the minimum: 5 errors with no explanation in the docs.

Status
Prefix PR title with [WIP] if necessary (changes not yet made).
Add tests to cover changes as needed.
Update documentation/changelog as needed.
Verify all tests run correctly in CI and pass.
Ready for review/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code paths are modified.
> 
> **Overview**
> Adds an **"Order requirements"** section to `README.md` describing the minimum order size (5 shares), minimum tick size (0.01), valid price range (0.01–0.99), and a note on small-$ orders at high prices causing `Size lower than the minimum: 5` rejections.
> 
> Also fixes a minor README formatting issue at the end of the file (removes a stray leading `-` and restores the trailing newline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72da864b6c6d385a8bbe7008f9f74ff6cab7f7ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->