### PR TITLE
Add Community Tools section — showcase projects built with py-clob-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,3 +271,8 @@ See [this Python example](https://gist.github.com/poly-rodr/44313920481de58d5a3f
 - Prices are in dollars from 0.00 to 1.00. Shares are whole or fractional units of the outcome token.
 
 See [/example](/examples) for more.
+## 🛠 Community Tools
+
+Projects built using py-clob-client:
+
+- [polymarket-whales](https://github.com/al1enjesus/polymarket-whales) - Real-time whale trade tracker — fires alerts when large orders hit the book. Terminal + Telegram, zero config.


### PR DESCRIPTION
Adding a **Community Tools** section to help users discover what's been built with py-clob-client.

First entry: **polymarket-whales** — a real-time whale trade tracker that uses this library to monitor large orders and fire alerts.

Helps drive adoption by showing concrete use cases.

https://github.com/al1enjesus/polymarket-whales

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an external project link; no code paths, APIs, or runtime behavior are affected.
> 
> **Overview**
> Adds a new **Community Tools** section to `README.md` to showcase projects built with `py-clob-client`, starting with a link and short description for `polymarket-whales`.
> 
> Also fixes the missing trailing newline around the existing “See `/examples`” note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb66360caaf939efd8ee6298aa5e1ebe36cb6359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->