### PR TITLE
fix: add None guard for params in get_balance_allowance and update_balance_allowance

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -934,6 +934,8 @@ class ClobClient:
         Requires Level 2 authentication
         """
         self.assert_level_2_auth()
+        if params is None:
+            raise ValueError("params is required for get_balance_allowance")
         request_args = RequestArgs(method="GET", request_path=GET_BALANCE_ALLOWANCE)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
         if params.signature_type == -1:
@@ -949,6 +951,8 @@ class ClobClient:
         Requires Level 2 authentication
         """
         self.assert_level_2_auth()
+        if params is None:
+            raise ValueError("params is required for update_balance_allowance")
         request_args = RequestArgs(method="GET", request_path=UPDATE_BALANCE_ALLOWANCE)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
         if params.signature_type == -1:

--- a/tests/test_balance_allowance.py
+++ b/tests/test_balance_allowance.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from py_clob_client.client import ClobClient
+from py_clob_client.clob_types import ApiCreds
+from py_clob_client.constants import AMOY
+
+# publicly known private key
+private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+creds = ApiCreds(
+    api_key="test-api-key",
+    api_secret="test-api-secret",
+    api_passphrase="test-api-passphrase",
+)
+
+
+class TestBalanceAllowance(TestCase):
+    def test_get_balance_allowance_requires_params(self):
+        client = ClobClient(
+            "https://clob.polymarket.com",
+            key=private_key,
+            chain_id=AMOY,
+            creds=creds,
+        )
+        with self.assertRaises(ValueError):
+            client.get_balance_allowance()
+
+    def test_update_balance_allowance_requires_params(self):
+        client = ClobClient(
+            "https://clob.polymarket.com",
+            key=private_key,
+            chain_id=AMOY,
+            creds=creds,
+        )
+        with self.assertRaises(ValueError):
+            client.update_balance_allowance()


### PR DESCRIPTION
## Overview

Fix AttributeError crash in `get_balance_allowance` and `update_balance_allowance` when called without `params` argument.

## Description

Both methods declare `params: BalanceAllowanceParams = None` as optional but immediately access `params.signature_type` without a None check. This causes an opaque `AttributeError: 'NoneType' object has no attribute 'signature_type'` when called without params.

This adds a guard at the top of each method that raises a clear `ValueError("params is required for ...")` before accessing any attributes.

No change to method signatures or behaviour for callers who pass params correctly.

This bug was also flagged during code review of #224.

## Testing instructions

Run the new test file: pytest tests/test_balance_allowance.py

## Types of changes

- [ ] Refactor/enhancement
- [x] Bug fix/behavior correction
- [ ] New feature
- [ ] Breaking change
- [ ] Other, additional

## Notes

Fixes #306 

## Status

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [x] Add tests to cover changes as needed.
- [ ] Update documentation/changelog as needed.
- [x] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds early input validation and tests, without changing request construction for valid callers.
> 
> **Overview**
> Fixes a crash in `ClobClient.get_balance_allowance` and `ClobClient.update_balance_allowance` by explicitly rejecting missing `params` with a clear `ValueError` before accessing `params.signature_type`.
> 
> Adds unit tests asserting both methods raise when called without parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b5554eab5b426dfe95c1640d47042b89e27a5b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->