### PR TITLE
fix: use str Enum instead of enumerate for OrderType and AssetType

### DIFF
--- a/py_clob_client/clob_types.py
+++ b/py_clob_client/clob_types.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any
 from dataclasses import dataclass, asdict
 from json import dumps
@@ -9,7 +10,7 @@ from py_order_utils.model import (
 from .constants import ZERO_ADDRESS
 
 
-class OrderType(enumerate):
+class OrderType(str, Enum):
     GTC = "GTC"
     FOK = "FOK"
     GTD = "GTD"
@@ -184,7 +185,7 @@ class OrderBookSummary:
         return dumps(self.__dict__, separators=(",", ":"))
 
 
-class AssetType(enumerate):
+class AssetType(str, Enum):
     COLLATERAL = "COLLATERAL"
     CONDITIONAL = "CONDITIONAL"
 


### PR DESCRIPTION
## Summary
`OrderType` and `AssetType` in `clob_types.py` inherit from the builtin `enumerate` function instead of `enum.Enum`. This means they don't behave as proper enums.

Uses `(str, Enum)` rather than plain `Enum` to preserve backwards compatibility — `OrderType` values are passed directly into JSON payloads via `order_to_json()`, and `AssetType` values are stringified in query params via `__str__()`. The `str` mixin ensures `OrderType.GTC == "GTC"` remains true.

Closes #251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces incorrect `enumerate` inheritance with `str, Enum` for two type definitions; behavioral impact should be limited to enum semantics/serialization but could affect any code relying on the previous non-enum behavior.
> 
> **Overview**
> Fixes `OrderType` and `AssetType` in `clob_types.py` to be real enums by switching inheritance from the builtin `enumerate` to `Enum`, mixed with `str` to keep them JSON/query-param friendly.
> 
> This improves type safety and enum behavior (e.g., comparisons/validation) while preserving string compatibility for existing request-building paths that pass these values through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e439018f7722aef6d6cfaf8c8fd00cfc25c137dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->