### PR TITLE
refactor: add specific type hints for all `side: str`

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -1,7 +1,7 @@
 import logging
 import json
 import time
-from typing import Optional
+from typing import Literal, Optional
 
 from py_builder_signing_sdk.config import BuilderConfig
 
@@ -1060,7 +1060,7 @@ class ClobClient:
         return results
 
     def calculate_market_price(
-        self, token_id: str, side: str, amount: float, order_type: OrderType
+        self, token_id: str, side: Literal["BUY", "SELL"], amount: float, order_type: OrderType
     ) -> float:
         """
         Calculates the matching price considering an amount and the current orderbook

--- a/py_clob_client/clob_types.py
+++ b/py_clob_client/clob_types.py
@@ -39,7 +39,7 @@ class RequestArgs:
 @dataclass
 class BookParams:
     token_id: str
-    side: str = ""
+    side: Literal["BUY", "SELL", ""] = ""
 
 
 @dataclass
@@ -59,7 +59,7 @@ class OrderArgs:
     Size in terms of the ConditionalToken
     """
 
-    side: str
+    side: Literal["BUY", "SELL"]
     """
     Side of the order
     """
@@ -98,7 +98,7 @@ class MarketOrderArgs:
     SELL orders: Shares to sell
     """
 
-    side: str
+    side: Literal["BUY", "SELL"]
     """
     Side of the order
     """

--- a/py_clob_client/order_builder/builder.py
+++ b/py_clob_client/order_builder/builder.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from py_order_utils.builders import OrderBuilder as UtilsOrderBuilder
 from py_order_utils.signer import Signer as UtilsSigner
 from py_order_utils.model import (
@@ -49,7 +51,7 @@ class OrderBuilder:
         self.funder = funder if funder is not None else self.signer.address()
 
     def get_order_amounts(
-        self, side: str, size: float, price: float, round_config: RoundConfig
+        self, side: Literal["BUY", "SELL"], size: float, price: float, round_config: RoundConfig
     ):
         raw_price = round_normal(price, round_config.price)
 
@@ -83,7 +85,7 @@ class OrderBuilder:
             raise ValueError(f"order_args.side must be '{BUY}' or '{SELL}'")
 
     def get_market_order_amounts(
-        self, side: str, amount: float, price: float, round_config: RoundConfig
+        self, side: Literal["BUY", "SELL"], amount: float, price: float, round_config: RoundConfig
     ):
         raw_price = round_normal(price, round_config.price)
 

--- a/py_clob_client/rfq/rfq_types.py
+++ b/py_clob_client/rfq/rfq_types.py
@@ -29,7 +29,7 @@ class RfqUserRequest:
     price: float
     """Price per token (0 < price < 1)."""
 
-    side: str
+    side: Literal["BUY", "SELL"]
     """Order side: "BUY" or "SELL"."""
 
     size: float
@@ -54,7 +54,7 @@ class RfqUserQuote:
     price: float
     """Price per token (0 < price < 1)."""
 
-    side: str
+    side: Literal["BUY", "SELL"]
     """Quoter's side: "BUY" or "SELL"."""
 
     size: float


### PR DESCRIPTION
<!-- Delete any sub-sections not used rather than leaving them empty. -->

## Overview

<!-- Provide a brief (1-3 sentence) summary of the PR and it's purpose. May include plans if a [WIP]. -->

## Description

Add specific type hints for all `side: str`. Generally, they are `side: Literal["BUY", "SELL"]`

## Types of changes

<!-- Check one of the boxes below, and add additional information as necessary. -->

- [x] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [ ] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

## Notes

<!-- Include any additional comments, links, questions, or discussion items here. -->

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [x] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [x] Add tests to cover changes as needed.
- [x] Update documentation/changelog as needed.
- [x] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to type annotations; runtime behavior is unchanged, though stricter typing may surface downstream mypy/IDE warnings where non-supported `side` strings are passed.
> 
> **Overview**
> Tightens type hints across the client, order builder, and RFQ types by replacing generic `side: str` parameters with `Literal["BUY", "SELL"]` (and `""` where optional) to make valid order sides explicit.
> 
> Updates affected function signatures and dataclass fields (e.g., `OrderArgs`, `MarketOrderArgs`, `BookParams`, RFQ user inputs, and `calculate_market_price`) and adds the necessary `Literal` imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83edd53faa66c4dcc3b5772503b544c85808ce43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->