### PR TITLE
fix: add None guard for params in get_balance_allowance and update_balance_allowance

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -934,6 +934,8 @@ class ClobClient:
         Requires Level 2 authentication
         """
         self.assert_level_2_auth()
+        if params is None:
+            raise ValueError("params is required for get_balance_allowance")
         request_args = RequestArgs(method="GET", request_path=GET_BALANCE_ALLOWANCE)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
         if params.signature_type == -1:
@@ -949,6 +951,8 @@ class ClobClient:
         Requires Level 2 authentication
         """
         self.assert_level_2_auth()
+        if params is None:
+            raise ValueError("params is required for update_balance_allowance")
         request_args = RequestArgs(method="GET", request_path=UPDATE_BALANCE_ALLOWANCE)
         headers = create_level_2_headers(self.signer, self.creds, request_args)
         if params.signature_type == -1:

--- a/tests/test_balance_allowance.py
+++ b/tests/test_balance_allowance.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from py_clob_client.client import ClobClient
+from py_clob_client.clob_types import ApiCreds
+from py_clob_client.constants import AMOY
+
+# publicly known private key (Hardhat #0)
+private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+creds = ApiCreds(
+    api_key="test-api-key",
+    api_secret="test-api-secret",
+    api_passphrase="test-api-passphrase",
+)
+
+
+class TestBalanceAllowance(TestCase):
+    def test_get_balance_allowance_requires_params(self):
+        client = ClobClient(
+            "https://clob.polymarket.com",
+            key=private_key,
+            chain_id=AMOY,
+            creds=creds,
+        )
+        with self.assertRaises(ValueError):
+            client.get_balance_allowance()
+
+    def test_update_balance_allowance_requires_params(self):
+        client = ClobClient(
+            "https://clob.polymarket.com",
+            key=private_key,
+            chain_id=AMOY,
+            creds=creds,
+        )
+        with self.assertRaises(ValueError):
+            client.update_balance_allowance()


### PR DESCRIPTION
## Summary
Fixes #306

Adds a `None` guard to `get_balance_allowance` and `update_balance_allowance` to prevent an opaque `AttributeError` when called without the `params` argument.

## Description

Both methods declare `params: BalanceAllowanceParams = None` as optional but immediately access `params.signature_type` without a None check. This causes an opaque `AttributeError: 'NoneType' object has no attribute 'signature_type'` when called without params.

This adds a guard **after** `self.assert_level_2_auth()` in each method that raises a clear `ValueError("params is required for ...")` before accessing any attributes. The guard is placed after the auth check to maintain consistent error semantics - unauthenticated callers always get the auth error first, matching the behavior of every other method in the class.

No change to method signatures or behaviour for callers who pass params correctly.

## Changes
- Added None check with clear ValueError in get_balance_allowance (after auth check)
- Added None check with clear ValueError in update_balance_allowance (after auth check)
- Added test file tests/test_balance_allowance.py covering both cases

## Testing
- pytest tests/test_balance_allowance.py - verifies both methods raise ValueError when called without params
- Existing test suite unchanged - no regressions for callers passing valid params

## Note
This addresses the review feedback on #307 (the None guard should be placed after assert_level_2_auth() to maintain consistent error ordering).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds explicit argument validation to two client methods and a small unit test, without changing request behavior for valid callers.
> 
> **Overview**
> Adds explicit `None` guards to `ClobClient.get_balance_allowance` and `ClobClient.update_balance_allowance`, raising a clear `ValueError` instead of failing later with an `AttributeError` when called without `params`.
> 
> Introduces `tests/test_balance_allowance.py` to assert both methods require `params` and error deterministically.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 987d5577eab83cfb66c4c7e145c9ed04307dbf80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->