### PR TITLE
feat: add proxy support to ClobClient initialization

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -162,8 +162,7 @@ class ClobClient:
         self.__fee_rates = {}
 
         # proxy
-        if proxy:
-            set_proxy(proxy)
+        set_proxy(proxy)
 
         # RFQ client
         self.rfq = RfqClient(self)

--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -89,6 +89,7 @@ from .http_helpers.helpers import (
     delete,
     get,
     post,
+    set_proxy,
     drop_notifications_query_params,
     add_balance_allowance_params_to_url,
     add_order_scoring_params_to_url,
@@ -124,6 +125,7 @@ class ClobClient:
         funder: str = None,
         builder_config: BuilderConfig = None,
         tick_size_ttl: float = 300.0,
+        proxy: Optional[str] = None,
     ):
         """
         Initializes the clob client
@@ -158,6 +160,10 @@ class ClobClient:
         self.__tick_size_ttl = tick_size_ttl
         self.__neg_risk = {}
         self.__fee_rates = {}
+
+        # proxy
+        if proxy:
+            set_proxy(proxy)
 
         # RFQ client
         self.rfq = RfqClient(self)

--- a/py_clob_client/http_helpers/helpers.py
+++ b/py_clob_client/http_helpers/helpers.py
@@ -25,10 +25,14 @@ def set_proxy(proxy: str = None):
     Pass None or empty string to disable proxy.
     """
     global _http_client
+
+    old_client = _http_client
     kwargs = {"http2": True}
     if proxy:
         kwargs["proxy"] = proxy
+
     _http_client = httpx.Client(**kwargs)
+    old_client.close()
 
 
 def overloadHeaders(method: str, headers: dict) -> dict:

--- a/py_clob_client/http_helpers/helpers.py
+++ b/py_clob_client/http_helpers/helpers.py
@@ -19,6 +19,18 @@ PUT = "PUT"
 _http_client = httpx.Client(http2=True)
 
 
+def set_proxy(proxy: str = None):
+    """
+    Reconfigures the shared HTTP client to use the given proxy.
+    Pass None or empty string to disable proxy.
+    """
+    global _http_client
+    kwargs = {"http2": True}
+    if proxy:
+        kwargs["proxy"] = proxy
+    _http_client = httpx.Client(**kwargs)
+
+
 def overloadHeaders(method: str, headers: dict) -> dict:
     if headers is None:
         headers = dict()

--- a/tests/http_helpers/test_proxy.py
+++ b/tests/http_helpers/test_proxy.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from py_clob_client.http_helpers.helpers import set_proxy
+
+
+class TestProxy(TestCase):
+    @patch("py_clob_client.http_helpers.helpers.httpx.Client")
+    def test_set_proxy_creates_client_with_proxy(self, mock_client_cls):
+        """set_proxy should create a new httpx.Client with the proxy param."""
+        set_proxy("http://localhost:8080")
+        mock_client_cls.assert_called_once_with(http2=True, proxy="http://localhost:8080")
+
+    @patch("py_clob_client.http_helpers.helpers.httpx.Client")
+    def test_set_proxy_none_creates_client_without_proxy(self, mock_client_cls):
+        """set_proxy(None) should create a client without the proxy param."""
+        set_proxy(None)
+        mock_client_cls.assert_called_once_with(http2=True)
+
+    @patch("py_clob_client.http_helpers.helpers.httpx.Client")
+    def test_set_proxy_empty_string_creates_client_without_proxy(self, mock_client_cls):
+        """set_proxy('') should create a client without the proxy param."""
+        set_proxy("")
+        mock_client_cls.assert_called_once_with(http2=True)

--- a/tests/http_helpers/test_proxy.py
+++ b/tests/http_helpers/test_proxy.py
@@ -8,17 +8,32 @@ class TestProxy(TestCase):
     @patch("py_clob_client.http_helpers.helpers.httpx.Client")
     def test_set_proxy_creates_client_with_proxy(self, mock_client_cls):
         """set_proxy should create a new httpx.Client with the proxy param."""
+        old_client = MagicMock()
+        mock_client_cls.side_effect = [old_client, MagicMock()]
+
         set_proxy("http://localhost:8080")
-        mock_client_cls.assert_called_once_with(http2=True, proxy="http://localhost:8080")
+
+        mock_client_cls.assert_called_with(http2=True, proxy="http://localhost:8080")
+        old_client.close.assert_called_once()
 
     @patch("py_clob_client.http_helpers.helpers.httpx.Client")
     def test_set_proxy_none_creates_client_without_proxy(self, mock_client_cls):
         """set_proxy(None) should create a client without the proxy param."""
+        old_client = MagicMock()
+        mock_client_cls.side_effect = [old_client, MagicMock()]
+
         set_proxy(None)
-        mock_client_cls.assert_called_once_with(http2=True)
+
+        mock_client_cls.assert_called_with(http2=True)
+        old_client.close.assert_called_once()
 
     @patch("py_clob_client.http_helpers.helpers.httpx.Client")
     def test_set_proxy_empty_string_creates_client_without_proxy(self, mock_client_cls):
         """set_proxy('') should create a client without the proxy param."""
+        old_client = MagicMock()
+        mock_client_cls.side_effect = [old_client, MagicMock()]
+
         set_proxy("")
-        mock_client_cls.assert_called_once_with(http2=True)
+
+        mock_client_cls.assert_called_with(http2=True)
+        old_client.close.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes #309

Adds optional `proxy` parameter to `ClobClient` initialization, allowing users in regions with restricted access to configure an HTTP/HTTPS proxy for all CLOB API requests.

## Changes
- Added `set_proxy(proxy)` function to `py_clob_client/http_helpers/helpers.py` that reconfigures the shared `httpx.Client` with the given proxy URL
- Added optional `proxy: Optional[str] = None` parameter to `ClobClient.__init__` — when provided, calls `set_proxy()` during initialization
- Added unit tests for `set_proxy()` in `tests/http_helpers/test_proxy.py`

## Usage
```python
from py_clob_client.client import ClobClient

# With proxy
client = ClobClient(
    host="https://clob.polymarket.com",
    chain_id=137,
    key="0x...",
    proxy="http://user:pass@proxy-host:8080",
)

# Without proxy (default, backward-compatible)
client = ClobClient(
    host="https://clob.polymarket.com",
    chain_id=137,
    key="0x...",
)
```

## Testing
- Added `tests/http_helpers/test_proxy.py` with 3 test cases covering proxy set, proxy=None, and proxy="" (empty string)
- No new dependencies required — `httpx` natively supports the `proxy` parameter
- Fully backward-compatible: `proxy` defaults to `None`, preserving existing behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new global `httpx.Client` reconfiguration path and closes/replaces the shared client, which could affect connection reuse or concurrent callers if used in multi-client scenarios.
> 
> **Overview**
> Adds optional proxy configuration for all API requests by introducing `set_proxy()` in `http_helpers/helpers.py`, which rebuilds the shared `httpx.Client` with (or without) a `proxy` setting.
> 
> `ClobClient.__init__` now accepts `proxy` and applies it during client construction, and new unit tests validate proxy/non-proxy behavior and that the old client is closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f9e4016a9d12d7d9bcfd779dd7f1dd33fd56422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->