### PR TITLE
fix: add configurable HTTP timeout and preserve error context

### DIFF
--- a/py_clob_client/client.py
+++ b/py_clob_client/client.py
@@ -84,6 +84,7 @@ from .clob_types import (
 )
 from .exceptions import PolyException
 from .http_helpers.helpers import (
+    set_http_timeout,
     add_query_trade_params,
     add_query_open_orders_params,
     delete,
@@ -124,6 +125,7 @@ class ClobClient:
         funder: str = None,
         builder_config: BuilderConfig = None,
         tick_size_ttl: float = 300.0,
+        timeout: float = None,
     ):
         """
         Initializes the clob client
@@ -142,6 +144,9 @@ class ClobClient:
         self.signer = Signer(key, chain_id) if key else None
         self.creds = creds
         self.mode = self._get_client_mode()
+
+        if timeout is not None:
+            set_http_timeout(timeout)
 
         if self.signer:
             self.builder = OrderBuilder(

--- a/py_clob_client/http_helpers/helpers.py
+++ b/py_clob_client/http_helpers/helpers.py
@@ -19,6 +19,14 @@ PUT = "PUT"
 _http_client = httpx.Client(http2=True)
 
 
+def set_http_timeout(timeout: float) -> None:
+    """
+    Reconfigure the module-level HTTP client with a custom timeout (in seconds).
+    """
+    global _http_client
+    _http_client = httpx.Client(http2=True, timeout=timeout)
+
+
 def overloadHeaders(method: str, headers: dict) -> dict:
     if headers is None:
         headers = dict()
@@ -61,8 +69,8 @@ def request(endpoint: str, method: str, headers=None, data=None):
         except ValueError:
             return resp.text
 
-    except httpx.RequestError:
-        raise PolyApiException(error_msg="Request exception!")
+    except httpx.RequestError as exc:
+        raise PolyApiException(error_msg=f"Request exception: {exc}") from exc
 
 
 def post(endpoint, headers=None, data=None):


### PR DESCRIPTION
## Summary

Fixes #273.

The default httpx timeout (~5s) causes silent order duplication under load: requests time out client-side, the SDK raises a generic PolyApiException, callers assume failure and retry, but the original order was already matched server-side. Multiple users reported duplicate fills from this behavior.

## Changes

- Added optional `timeout` parameter to `ClobClient.__init__()` — when provided, reconfigures the module-level httpx client with the specified timeout in seconds
- Preserved the original httpx.RequestError via exception chaining (raise ... from exc) so callers can distinguish timeouts from DNS failures, connection resets, etc.
- Fully backward compatible: default behavior unchanged when timeout is not specified

## Usage

```python
client = ClobClient(
    host="https://clob.polymarket.com",
    key=key,
    chain_id=137,
    timeout=30,
)
```

## Test plan

- [x] Verified default behavior unchanged (no timeout arg = httpx default)
- [x] Verified timeout=30 reconfigures the client correctly
- [x] Verified exception chaining preserves original error type and message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP client configuration and error propagation for all SDK requests, which could alter runtime behavior (timeouts) and exception handling in consumers.
> 
> **Overview**
> Adds an optional `timeout` argument to `ClobClient.__init__` that reconfigures the module-level `httpx` client via new `set_http_timeout`, allowing callers to override default request timeouts.
> 
> Improves HTTP error reporting by including the original `httpx.RequestError` message and chaining the exception (`raise ... from exc`) so consumers can distinguish timeouts and connection failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b69208fa307816d22e752a3e3c26eaa4507502f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->