### PR TITLE
fix: use round_down for market order price

### DIFF
--- a/py_clob_client/order_builder/builder.py
+++ b/py_clob_client/order_builder/builder.py
@@ -85,7 +85,7 @@ class OrderBuilder:
     def get_market_order_amounts(
         self, side: str, amount: float, price: float, round_config: RoundConfig
     ):
-        raw_price = round_normal(price, round_config.price)
+        raw_price = round_down(price, round_config.price)
 
         if side == BUY:
             raw_maker_amt = round_down(amount, round_config.size)

--- a/tests/order_builder/test_builder.py
+++ b/tests/order_builder/test_builder.py
@@ -12,7 +12,7 @@ from py_clob_client.order_builder.constants import BUY, SELL
 
 from py_clob_client.signer import Signer
 from py_clob_client.order_builder.builder import OrderBuilder, ROUNDING_CONFIG
-from py_clob_client.order_builder.helpers import decimal_places, round_normal
+from py_clob_client.order_builder.helpers import decimal_places, round_normal, round_down
 from py_order_utils.model import (
     POLY_GNOSIS_SAFE,
     EOA,
@@ -3442,3 +3442,34 @@ class TestOrderBuilder(TestCase):
             / float(signed_order.order["makerAmount"]),
             0.0056,
         )
+
+    def test_market_order_uses_round_down_for_price(self):
+        """
+        Regression test for #323: get_market_order_amounts should use
+        round_down for price, not round_normal, to match the TypeScript
+        client and avoid rounding prices in the unfavorable direction.
+
+        With price=0.555 and tick_size="0.01" (price precision=2):
+          round_normal(0.555, 2) = 0.56  (rounds up — worse for buyer)
+          round_down(0.555, 2)   = 0.55  (rounds down — correct)
+        """
+        builder = OrderBuilder(signer)
+        config = ROUNDING_CONFIG["0.01"]
+
+        # BUY: higher price means fewer shares per dollar — round_down is favorable
+        side, maker, taker = builder.get_market_order_amounts(
+            BUY, 100.0, 0.555, config
+        )
+        self.assertEqual(side, UtilsBuy)
+        # With round_down, effective price is 0.55, so taker = 100/0.55 = 181.81...
+        # With round_normal, effective price would be 0.56, taker = 100/0.56 = 178.57...
+        # Verify price used was 0.55 (round_down), not 0.56 (round_normal)
+        effective_price = round_down(maker / taker, config.price)
+        self.assertEqual(effective_price, round_down(0.555, config.price))
+        self.assertNotEqual(effective_price, round_normal(0.555, config.price))
+
+        # SELL: lower price means less received — round_down is conservative
+        side, maker, taker = builder.get_market_order_amounts(
+            SELL, 100.0, 0.555, config
+        )
+        self.assertEqual(side, UtilsSell)


### PR DESCRIPTION
`get_market_order_amounts` uses `round_normal` for price, but the TypeScript client uses `roundDown` in the equivalent `getMarketOrderRawAmounts` ([helpers.ts:200](https://github.com/Polymarket/clob-client/blob/main/src/order-builder/helpers.ts#L200)).

`round_normal` can round up (e.g. `0.555` → `0.56` with 2 decimal precision), producing a worse effective price for BUY market orders — fewer shares per dollar.

This changes line 88 of `builder.py` from `round_normal` to `round_down` for market orders only. Limit orders (`get_order_amounts`) are unchanged and correctly use `round_normal` in both clients.

Includes a regression test using a price that diverges between the two rounding methods.

Closes #323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes market order price rounding, which directly affects computed maker/taker amounts and effective execution price. Risk is contained to market orders but could impact downstream order validation and user outcomes if rounding assumptions differ.
> 
> **Overview**
> Market order construction now rounds the input `price` *down* (via `round_down`) in `get_market_order_amounts` instead of using `round_normal`, preventing cases where mid-tick prices round up and produce a worse effective price (notably for BUY market orders).
> 
> Adds a regression test (`test_market_order_uses_round_down_for_price`) that exercises a price (`0.555` with `tick_size="0.01"`) where `round_normal` and `round_down` diverge, ensuring the builder matches the expected (TypeScript-aligned) rounding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9827a94e657a1e20dbf3af72c739e7b4ac1313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->