### PR TITLE
fix: use round_down for price in market orders (closes #323)

### DIFF
--- a/py_clob_client/order_builder/builder.py
+++ b/py_clob_client/order_builder/builder.py
@@ -85,7 +85,7 @@ class OrderBuilder:
     def get_market_order_amounts(
         self, side: str, amount: float, price: float, round_config: RoundConfig
     ):
-        raw_price = round_normal(price, round_config.price)
+        raw_price = round_down(price, round_config.price)
 
         if side == BUY:
             raw_maker_amt = round_down(amount, round_config.size)


### PR DESCRIPTION
## Problem
`get_market_order_amounts` uses `round_normal` for `raw_price`, which can
round the price *up* when the fractional part is >= 0.5. This causes the
computed maker/taker amounts to diverge from the TypeScript client, which
consistently uses `round_down` for price in market orders.

## Fix
Replace `round_normal` with `round_down` for `raw_price` inside
`get_market_order_amounts` only. The `get_order_amounts` (limit orders)
function is intentionally left unchanged.

## References
Closes #323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rounding behavior for `raw_price` in market orders, which can alter computed maker/taker amounts and downstream order signing/execution. Risk is limited in scope but affects trading amount calculations.
> 
> **Overview**
> Market-order amount calculation now always rounds `price` *down* (replacing `round_normal` with `round_down`) in `get_market_order_amounts`, preventing price rounding up from shifting computed maker/taker amounts.
> 
> Limit-order pricing via `get_order_amounts` is unchanged, keeping prior rounding behavior there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff37563e953fd445597772f6975ec59f3c52eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->