### PR TITLE
docs(readme): add per-market fee rate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,25 @@ trades = client.get_trades()
 print(last, len(trades))
 ```
 
+### Fee rates (per market)
+
+Fees are set per market and can change over time. Always query the live rate for the specific token you are trading rather than assuming a fixed value — different markets in the same category can return different rates.
+
+```python
+from py_clob_client.client import ClobClient
+
+client = ClobClient("https://clob.polymarket.com")
+
+token_id = "<token-id>"
+fee_rate_bps = client.get_fee_rate_bps(token_id)  # calls GET /fee-rate?token_id=...
+print(f"base_fee: {fee_rate_bps} bps")
+```
+
+Notes:
+- The value is in basis points (e.g. `1000` = 10%, `0` = no fee on that market).
+- When creating orders, the client automatically resolves the market's fee rate via `get_fee_rate_bps`. If you pass a non‑zero `fee_rate_bps` in `OrderArgs`, it must match the market's rate or order creation raises.
+- Fees are applied on-chain by the CTF Exchange. The authoritative calculation lives in [`CalculatorHelper.sol`](https://github.com/Polymarket/ctf-exchange/blob/main/src/exchange/libraries/CalculatorHelper.sol).
+
 ## Important: Token Allowances for MetaMask/EOA Users
 
 ### Do I need to set allowances?


### PR DESCRIPTION
Refs #326.

### What changed
Adds a short **Fee rates (per market)** section to `README.md` showing how to query the live fee rate for a given token via the existing `get_fee_rate_bps(token_id)` method.

### Why
The library already calls `GET /fee-rate?token_id=...` under the hood when creating orders, but the README never mentions the method or the fact that fees are market-specific. Issue #326 reports that the public fee docs imply a single static rate per category, while `/fee-rate` actually returns different values per market (e.g. `0` for some NHL markets, `1000` bps for NBA/MLB).

This PR stays strictly within what the code and endpoint already do:
- Documents the public `get_fee_rate_bps` method.
- States the unit (basis points) and shows how to call it.
- Notes that the client will raise if a user-supplied `fee_rate_bps` conflicts with the resolved market rate — this matches the behavior in `__resolve_fee_rate`.
- Points readers to [`CalculatorHelper.sol`](https://github.com/Polymarket/ctf-exchange/blob/main/src/exchange/libraries/CalculatorHelper.sol) for the authoritative on-chain fee calculation.

### Scope
- One file (`README.md`), additive section only.
- No code changes.
- Deliberately does **not** assert a specific fee formula or category-level rate — those questions in #326 are for maintainers to answer on the public docs site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds a new **“Fee rates (per market)”** section to `README.md` documenting that fees vary by market and can change over time, and showing how to query the live rate via `client.get_fee_rate_bps(token_id)`.
> 
> Clarifies units (basis points), notes order creation will validate any user-supplied `fee_rate_bps` against the market’s resolved rate, and links to the on-chain fee calculation source (`CalculatorHelper.sol`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9355236ac3bc8ed1816f50a362bce0693a3aadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->