### PR TITLE
docs: point migration link to unified py-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 >
 > The client is no longer functional and should not be used for new or existing integrations.
 >
-> Please migrate to the V2 client:
-> https://github.com/Polymarket/py-clob-client-v2
+> Please migrate to our new unified SDK:
+> https://github.com/Polymarket/py-sdk
 
 # Polymarket Python CLOB Client
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a migration URL in README; no runtime or security impact.
> 
> **Overview**
> Updates the **archived repository** warning so integrators are directed to Polymarket’s **unified Python SDK** (`https://github.com/Polymarket/py-sdk`) instead of the older **V2 CLOB client** repo (`py-clob-client-v2`). Wording changes from “migrate to the V2 client” to “migrate to our new unified SDK.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da333b2c477fcdc398c2d5470c988c8e15ebb180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->